### PR TITLE
Delay MARX C code import until needed

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,6 +2,8 @@
 Installation
 ============
 
+.. _sect-installmarxccode:
+
 `marx`_ C code
 ==============
 In order to build the interface to the `marx`_ C code, you need to set the path


### PR DESCRIPTION
This should help in building the docs and in cases where marxs is run on a system where marx (no S!) is not installed. Without this patch, it would raise an ImportError for almost every optical element, now the C code is only imported if a marx C module is actually called.