### PR TITLE
Refactor sources

### DIFF
--- a/marxs/design/test/test_design.py
+++ b/marxs/design/test/test_design.py
@@ -16,7 +16,7 @@ def parametrictorus(R, r, theta, phi):
     return np.array([x, y, z]).T
 
 def test_radius_of_photon_shell():
-    mysource = ConstantPointSource((30., 30.), 1., 1.)
+    mysource = ConstantPointSource((30., 30.), flux=1., energy=1.)
     photons = mysource.generate_photons(1000)
     mypointing = FixedPointing(coords=(30, 30.))
     photons = mypointing.process_photons(photons)

--- a/marxs/math/random.py
+++ b/marxs/math/random.py
@@ -57,11 +57,11 @@ class RandomArbitraryPdf(object):
         if not np.all(pdf >= 0):
             raise ValueError('pdf cannot have negative elements.')
 
-        self.x = x
+        self.x = np.asarray(x)
         self.bin_width = np.hstack(([0], np.diff(x)))
         if not np.all(self.bin_width >=0):
             raise ValueError('x must be input in increasing order.')
-        pdf = pdf * self.bin_width
+        pdf = np.asarray(pdf) * self.bin_width
         self.sort = sort
         self.randomize_in_bin = randomize_in_bin
 

--- a/marxs/math/random.py
+++ b/marxs/math/random.py
@@ -1,0 +1,93 @@
+import numpy as np
+
+class RandomArbitraryPdf(object):
+    '''Take random draw from an arbitrary (and arbitrarily binned) pdf.
+
+    The PDF is approximated as piecewice constant.
+    The object is initialized with a parameters that describe the PDF, the object can
+    then be called with the number of random samples that are required.
+
+    Parameters
+    ----------
+    x : np.array
+        **Upper** bin edge for input bins
+    pdf : np.array
+        Value of the pdf for each bin. ``pdf[0]`` is ignored, since the lower edge
+        of that bin is undefined.
+    randomize_in_bin : bool
+        If ``True`` randomize the return value over each bin. If ``False`` the return
+        value will be exactly the **upper** bin edge.
+    sort : bool
+        When calculating the cdf from a pdf that covers a large dynamical range,
+        round-off errors may occur. If ``True`` this sorts the input bins in size
+        (keeping an index for reverse the operation later) to avoid numerical errors.
+
+    Examples
+    --------
+    First, and example with two bins (1-2 and 2-3). The probability density for each
+    bin is 1 and 6, respectively (the 0.2 is ignored, because the range XXX - 1 is not
+    a valid bin since the lower bound is undefined).
+
+    >>> import numpy as np
+    >>> # Set seed so this example returns exact same numbers every time
+    >>> np.random.seed(0)
+    >>> a = RandomArbitraryPdf(np.array([1,2,3]), np.array([0.2,1,6]))
+    >>> array([ 2.79172504,  2.52889492,  2.56804456,  2.92559664,  2.07103606,
+    ...     2.0871293 ,  2.0202184 ,  2.83261985,  2.77815675,  2.87001215])
+
+    As you can see, in this case the chance to draw from the 1-2 interval is only
+    1/7 and it did not happen this time.
+
+    If, instead, we want to have exact bin edges returned it looks like this:
+    >>> a = RandomArbitraryPdf(np.array([1,2,3]), np.array([0,1,6]), randomize_in_bin=False)
+    >>> a(10)
+    array([2, 2, 2, 2, 1, 2, 2, 2, 2, 2])
+
+    As expected, most numbers are 2, with a 1 mixed in.
+
+    References
+    ----------
+    https://en.wikipedia.org/wiki/Pseudorandom_number_generator#Non-uniform_generators
+
+    http://stackoverflow.com/questions/21100716/
+    '''
+    def __init__(self, x, pdf, randomize_in_bin=True, sort=True):
+        if not len(x) == len(pdf):
+            raise ValueError('x and pdf must have same number of elements.')
+        if not np.all(pdf >= 0):
+            raise ValueError('pdf cannot have negative elements.')
+
+        self.x = x
+        self.bin_width = np.hstack(([0], np.diff(x)))
+        if not np.all(self.bin_width >=0):
+            raise ValueError('x must be input in increasing order.')
+        pdf = pdf * self.bin_width
+        self.sort = sort
+        self.randomize_in_bin = randomize_in_bin
+
+        # sort the pdf - otherwise bins with small numbers might be lost to round-off errors
+        # idea is from http://stackoverflow.com/questions/21100716/
+        if self.sort:
+            self.sortindex = np.argsort(pdf)
+            self.pdf = pdf[self.sortindex]
+        else:
+            self.pdf = pdf
+        # cumulative distribution function
+        self.cdf = np.cumsum(self.pdf)
+
+    def __call__(self, N):
+        """Draw from the distribution function. See docstring of class."""
+        #pick numbers which are uniformly random over the cumulative distribution function
+        choice = np.random.uniform(high=self.cdf[-1], size=N)
+        # Now here is the difficult and comparatively expensive part:
+        # We need a reverse lookup to find the bin in the cdf so that we an use it
+        # to map this back to the x values of the pdf
+        # np.searchsorted is a binary search with O(log n).
+        index = np.searchsorted(self.cdf, choice)
+        #if necessary, map the indices back to their original ordering
+        if self.sort:
+            index = self.sortindex[index]
+        if self.randomize_in_bin:
+            return self.x[index - 1] + self.bin_width[index] * np.random.rand(N)
+        else:
+            return self.x[index]

--- a/marxs/math/test/test_random.py
+++ b/marxs/math/test/test_random.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from ..random import RandomArbitraryPdf
+
+# Any number will do. Just make it repeatable.
+np.random.seed(12324)
+
+def test_return_right_pdf():
+    x = np.arange(10.)
+    f = x ** 2.
+    rand = RandomArbitraryPdf(x, f)
+    draws = rand(1e4)
+    draws.sort()
+    # there should be very few small numbers
+    assert draws[5000] > 5
+    # but a few of them
+    assert draws[2] <= 3
+    # check range
+    assert draws[0] >=0
+    assert draws[-1] < 10.
+
+def test_unequal_bins():
+    '''Almost all results should be from the 1-100 range because we are talking
+    probability DENSITY.'''
+    rand = RandomArbitraryPdf(np.array([0,1,100]), np.ones(3))
+    draws = rand(1e4)
+    draws.sort()
+    assert draws[1000] > 1

--- a/marxs/optics/test/test_interfacecomplience.py
+++ b/marxs/optics/test/test_interfacecomplience.py
@@ -26,7 +26,7 @@ all_oe = [ThinLens(focallength=100),
                                 facetargs={'zoom':0.05, 'd':0.002,
                                            'order_selector': constant_order_factory(1)
                                            }),
-		  Baffle()
+          Baffle()
           ]
 
 # Each elements will be used multiple times.
@@ -38,7 +38,7 @@ all_oe = [ThinLens(focallength=100),
 # Make a test photon list
 # Some of this should be separate tests, e.g. source position vs. pointing.
 # Can I vary energy for e.g. grating?
-mysource = ConstantPointSource((30., 30.), 1., 300.)
+mysource = ConstantPointSource((30., 30.), energy=1., flux=300.)
 masterphotons = mysource.generate_photons(11)
 mypointing = FixedPointing(coords=(30., 30.))
 masterphotons = mypointing.process_photons(masterphotons)

--- a/marxs/optics/test/test_marx.py
+++ b/marxs/optics/test/test_marx.py
@@ -19,7 +19,7 @@ def test_noexplicettimedependence():
     mirror shell 0, which turned out to be due to ``sorted_index`` being a int,
     while marx expects an *unsigned* int.
     '''
-    mysource = marxs.source.source.ConstantPointSource((30., 30.), 1., 1.)
+    mysource = marxs.source.source.ConstantPointSource((30., 30.), flux=1., energy=1.)
     photons = mysource.generate_photons(1000)
     mypointing = marxs.source.source.FixedPointing(coords=(30, 30.))
     photons = mypointing.process_photons(photons)

--- a/marxs/optics/test/test_optics.py
+++ b/marxs/optics/test/test_optics.py
@@ -16,7 +16,7 @@ import marxs.source.source
 @pytest.fixture(autouse=True)
 def photons1000():
     '''Make a list of photons parallel to optical axis'''
-    mysource = marxs.source.source.ConstantPointSource((30., 30.), 1., 300.)
+    mysource = marxs.source.source.ConstantPointSource((30., 30.), energy=1., flux=300.)
     np.random.seed(0)
     p = mysource.generate_photons(1000)
     mypointing = marxs.source.source.FixedPointing(coords=(30., 30.))

--- a/marxs/source/source.py
+++ b/marxs/source/source.py
@@ -4,22 +4,102 @@ from transforms3d.euler import euler2mat
 
 from ..base import SimulationSequenceElement
 from ..optics.polarization import polarization_vectors
+from ..math.random import RandomArbitraryPdf
 
-'''TO-DO: make proper object hirachy, always call super on init. Pass args through, e.g. for name.'''
+def random_polarization(n, dir_array):
+    # randomly choose polarization (temporary)
+    angles = np.random.uniform(0, 2 * np.pi, n)
+    return polarization_vectors(dir_array, angles)
+
+
+class timedependentspectrum(object):
+    '''
+
+    Example
+    ------
+    >>> mysource = Source(energy=timedependedspectrum(2.3, 3.4))
+    '''
+    def __init__(self, en1, en2):
+        self.en1 = en1
+        self.en2 = en2
+
+    def __call__(self, t):
+        energies = np.zeros_like(t)
+        energies[t < 1] = self.en1
+        energies[t >=1] = self.en2
+        return energies
+
 
 class Source(SimulationSequenceElement):
     '''Make this ABC once I have worked out the interface'''
+    def __init__(self, **kwargs):
+        self.energy = kwargs.pop('energy')
+        self.flux = kwargs.pop('flux')
+        self.polarization = kwargs.pop('polarization', None)
+
+        super(Source, self).__init__(**kwargs)
+
+    def generate_times(self, exposuretime):
+        if callable(self.flux):
+            return self.rate(exposuretime)
+        elif np.isscalar(self.flux):
+            return np.arange(0, exposuretime, 1./self.flux)
+        else:
+            raise ValueError('Rate must be a number of a callable.')
+
+    def generate_energies(self, t):
+        n = len(t)
+        # function
+        if callable(self.energy):
+            return self.energy(t)
+        # constant energy
+        elif np.isscalar(self.energy):
+            return np.ones(n) * self.energy
+        # 2 * n numpy array
+        elif hasattr(self.energy, 'shape') and (self.shape[0] == 2):
+            rand = RandomArbitraryPdf(self.energy[0, :], self.energy[1, :])
+            return rand(n)
+        # np.recarray or astropy.table.Table
+        elif hasattr(self.energy, '__getitem__'):
+            rand = RandomArbitraryPdf(self.energy['energy'], self.energy['flux'])
+            return rand(n)
+        # anything else
+        else:
+            raise ValueError('energy must be number, function, 2*n array or have fields "energy" and "flux".')
+
+
+    def generate_polarization(self, times, energies):
+        n = len(times)
+        # function
+        if callable(self.polarization):
+            return self.polarization(times, energies)
+        elif np.isscalar(self.polarization):
+            return np.ones(n) * self.polarization
+        # 2 * n numpy array
+        elif hasattr(self.energy, 'shape') and (self.shape[0] == 2):
+            rand = RandomArbitraryPdf(self.energy[0, :], self.energy[1, :])
+            return rand(n)
+        # np.recarray or astropy.table.Table
+        elif hasattr(self.energy, '__getitem__'):
+            rand = RandomArbitraryPdf(self.energy['angle'], self.energy['probability'])
+            return rand(n)
+        elif self.polarization is None:
+            return np.random.uniform(0, 2* np.pi, n)
+        else:
+            raise ValueError('polarization must be number (angle), callable, None (unpolarized), 2.n array or have fields "angle" (in rad) and "probability".')
+
     def generate_photon(self):
         pass
 
-    def generate_photons(self):
+    def generate_photons(self, exposuretime):
         # Similar to optics this could be given if generate_photons is given!
-        pass
-    
-    def random_polarization(self, n, dir_array):
-        # randomly choose polarization (temporary)
-        angles = np.random.uniform(0, 2 * np.pi, n)
-        return polarization_vectors(dir_array, angles)
+        times = self.generate_times(exposuretime)
+        energies = self.generate_energies(times)
+        pol = self.generate_polarization(times, energies)
+        n = len(times)
+        return Table({'time': times, 'energy': energies, 'polangle': pol,
+                      'probability': np.ones(n)})
+
 
 
 class ConstantPointSource(Source):
@@ -29,22 +109,16 @@ class ConstantPointSource(Source):
     - constant flux (I mean constant, not Poisson distributed - this is not
       an astrophysical source, it's for code testing.)
     '''
-    def __init__(self, coords, flux, energy, polarization=np.nan, effective_area=1):
+    def __init__(self, coords, **kwargs):
         self.coords = coords
-        self.flux = flux
-        self.effective_area = effective_area
-        self.rate = flux * effective_area
-        self.energy = energy
-        self.polarization = polarization
+        super(ConstantPointSource, self).__init__(**kwargs)
 
-    def generate_photons(self, t):
-        n = t  * self.rate
-        out = np.empty((6, n))
-        out[0, :] = np.arange(0, t, 1. / self.rate)
-        for i, val in enumerate([self.coords[0], self.coords[1], self.energy, self.polarization]):
-            out[i + 1, :] = val
-        out[5, :] = 1.
-        return Table(out.T, names = ('time', 'ra', 'dec', 'energy', 'polarization', 'probability'))
+    def generate_photons(self, exposuretime):
+        photons = super(ConstantPointSource, self).generate_photons(exposuretime)
+        photons['ra'] = np.ones(len(photons)) * self.coords[0]
+        photons['dec'] = np.ones(len(photons)) * self.coords[1]
+
+        return photons
 
 class SymbolFSource(Source):
     '''Source shaped like the letter F.
@@ -147,7 +221,6 @@ class FixedPointing(PointingModel):
         --------------------
         Negative sign for dec and roll, because these are defined
         opposite to the right hand rule.
-
         Note: I hope I figured it out right. If not, I can always bail
         and use astropy.coordinates for this.
         '''
@@ -170,4 +243,5 @@ class FixedPointing(PointingModel):
         photons['dir'][:, 2] = - np.sin(dec)
         photons['dir'][:, 3] = 0
         photons['dir'][:, :3] = np.dot(np.linalg.inv(self.mat3d), photons['dir'][:, :3].T).T
+        photons['polarization'] = np.ones_like(ra)
         return photons

--- a/marxs/source/source.py
+++ b/marxs/source/source.py
@@ -57,7 +57,7 @@ class Source(SimulationSequenceElement):
         elif np.isscalar(self.energy):
             return np.ones(n) * self.energy
         # 2 * n numpy array
-        elif hasattr(self.energy, 'shape') and (self.shape[0] == 2):
+        elif hasattr(self.energy, 'shape') and (self.energy.shape[0] == 2):
             rand = RandomArbitraryPdf(self.energy[0, :], self.energy[1, :])
             return rand(n)
         # np.recarray or astropy.table.Table
@@ -81,12 +81,12 @@ class Source(SimulationSequenceElement):
         elif np.isscalar(self.polarization):
             return np.ones(n) * self.polarization
         # 2 * n numpy array
-        elif hasattr(self.energy, 'shape') and (self.shape[0] == 2):
-            rand = RandomArbitraryPdf(self.energy[0, :], self.energy[1, :])
+        elif hasattr(self.polarization, 'shape') and (self.polarization.shape[0] == 2):
+            rand = RandomArbitraryPdf(self.polarization[0, :], self.polarization[1, :])
             return rand(n)
         # np.recarray or astropy.table.Table
-        elif hasattr(self.energy, '__getitem__'):
-            rand = RandomArbitraryPdf(self.energy['angle'], self.energy['probability'])
+        elif hasattr(self.polarization, '__getitem__'):
+            rand = RandomArbitraryPdf(self.polarization['angle'], self.polarization['probability'])
             return rand(n)
         elif self.polarization is None:
             return np.random.uniform(0, 2 * np.pi, n)

--- a/marxs/source/test/test_farLabPointSource.py
+++ b/marxs/source/test/test_farLabPointSource.py
@@ -7,11 +7,10 @@ def test_photon_generation():
 	the starting positions of the photons are within the aperture.
 	'''
 	pos = [1., 0., 0.]
-	polar = [0., 0., 0.]
 	rate = 10
 	center = [0., 0.5, 0.]
-	source = LabSource(pos, polar, rate, 5., position = center, zoom = [1., 1., 2.8])
-	
+	source = LabSource(pos, flux=rate, energy=5., position = center, zoom = [1., 1., 2.8])
+
 	photons = source.generate_photons(1.)
 	for i in range (0, 10):
 		assert photons['pos'][i][1] >= -0.5

--- a/marxs/source/test/test_labPointSource.py
+++ b/marxs/source/test/test_labPointSource.py
@@ -5,21 +5,19 @@ def test_photon_generation():
 	'''This tests the lab point source. It checks that the starting points are all
 	at the sources position.
 	'''
-	pos = [1., 1., 1.] 
-	polar = [0., 0., 0.] 
+	pos = [1., 1., 1.]
 	rate = 10
-	source = LabSource(pos, polar, rate, 5.)
-				    
+	source = LabSource(pos, flux=rate, energy=5.)
+
 	photons = source.generate_photons(1.)
 	assert np.all(photons['pos'] == np.ones([10, 4]))
 
 def test_photon_direction():
 	'''This tests the lab point source. It checks the optional 'direction' parameter.
 	'''
-	pos = [1., 1., 1.] 
-	polar = [0., 0., 0.] 
+	pos = [1., 1., 1.]
 	rate = 10
-	source = LabSource(pos, polar, rate, 5., direction = '-y')
-	
+	source = LabSource(pos, flux=rate, energy=5., direction = '-y')
+
 	photons = source.generate_photons(1.)
 	assert np.all(photons['dir'][:, 1] <= 0)

--- a/marxs/source/test/test_source.py
+++ b/marxs/source/test/test_source.py
@@ -1,0 +1,121 @@
+import numpy as np
+import pytest
+from astropy.table import Table
+
+from ..source import Source, SourceSpecificationError
+
+def test_energy_input_default():
+    '''For convenience and testing, defaults for time, energy and pol are set.'''
+    s = Source()
+    photons = s.generate_photons(5.1)
+    assert len(photons) == 5
+    assert np.all(photons['energy'] == 1.)
+    assert len(set(photons['pol_angle'])) == 5  # all pol angles are different
+
+def test_flux_input():
+    '''Options: contant rate or function'''
+    # 1. constant rate
+    s = Source(flux=5)
+    photons = s.generate_photons(5.01)
+    assert len(photons) == 25
+    delta_t = np.diff(photons['time'])
+    assert np.all(delta_t == delta_t[0]) # constante rate
+
+    # 2. function
+    def f(t):
+        return np.logspace(1, np.log10(t))
+
+    s = Source(flux=f)
+    photons = s.generate_photons(100)
+    assert np.all(photons['time'] == np.logspace(1, 2))
+
+    # 3. anything else
+    s = Source(flux=ValueError)
+    with pytest.raises(SourceSpecificationError) as e:
+        photons = s.generate_photons(5)
+    assert '`flux` must be' in str(e.value)
+
+def test_energy_input():
+    '''Many differnet options ...'''
+    # 1. contant energy
+    s = Source(energy=2.)
+    photons = s.generate_photons(5)
+    assert np.all(photons['energy'] == 2.)
+
+    # 2. function
+    def f(t):
+        return t
+    s = Source(energy=f)
+    photons = s.generate_photons(5)
+    assert np.all(photons['energy'] == photons['time'])
+    # bad function
+    s = Source(energy=np.sum)
+    with pytest.raises(SourceSpecificationError) as e:
+        photons = s.generate_photons(5)
+    assert 'an array of same size as' in str(e.value)
+
+    # 3. array, table, recarray, dict, ... just try some of of the opion with keys
+    # spectrum with distinct lines
+    engrid = [0.5, 1., 2., 3.]
+    fluxgrid = [456., 1., 0., 2.]  # first entry (456) will be ignored
+    s1 = Source(energy={'energy': engrid, 'flux': fluxgrid})
+    s2 = Source(energy=np.vstack([engrid, fluxgrid]))
+    s3 = Source(energy=Table({'energy': engrid, 'flux': fluxgrid}))
+    for s in [s1, s2, s3]:
+        photons = s.generate_photons(1000)
+        en = photons['energy']
+        ind0510 = (en >= 0.5) & (en <=1.0)
+        ind2030 = (en >= 2.) & (en <=3.0)
+        assert (ind0510.sum() + ind2030.sum()) == len(photons)
+        assert ind0510.sum() < ind3030.sum()
+
+    # 4. anything else
+    s = Source(energy=ValueError)
+    with pytest.raises(SourceSpecificationError) as e:
+        photons = s.generate_photons(5)
+    assert '`energy` must be' in str(e.value)
+
+def test_polarization_input():
+    '''Many differnet options ...'''
+    # 1. 100 % polarized flux
+    s = Source(polarization=2.)
+    photons = s.generate_photons(5)
+    assert np.all(photons['plo_angle'] == 2.)
+
+    # 2. function
+    def f(t, en):
+        return t * en
+    s = Source(polarization=f, energy=2.)
+    photons = s.generate_photons(5)
+    assert np.all(photons['pol_angle'] == photons['time'] * photons['energy'])
+    # bad function
+    s = Source(ploarization=np.dot)
+    with pytest.raises(SourceSpecificationError) as e:
+        photons = s.generate_photons(5)
+    assert 'an array of same size as' in str(e.value)
+
+    # 3. array, table, recarray, dict, ... just try some of of the opion with keys
+    # spectrum with distinct lines
+    polgrid = [0.5, 1., 2., 3.]
+    probgrid = [456., 1., 0., 2.]  # first entry (456) will be ignored
+    s1 = Source(ploarization={'angle': polgrid, 'probability': probgrid})
+    s2 = Source(polarization=np.vstack([polgrid, probgrid]))
+    s3 = Source(polarization=Table({'angle': polgrid, 'probability': probgrid}))
+    for s in [s1, s2, s3]:
+        photons = s.generate_photons(1000)
+        pol = photons['pol_angle']
+        ind0510 = (en >= 0.5) & (en <=1.0)
+        ind2030 = (en >= 2.) & (en <=3.0)
+        assert (ind0510.sum() + ind2030.sum()) == len(photons)
+        assert ind0510.sum() < ind3030.sum()
+
+    # 4. None (unpolarized source)
+    s = Source(polarization=None)
+    photons = s.generate_photons(5)
+    assert len(set(photons['pol_angle'])) == len(photons) # all different
+
+    # 5. anything else
+    s = Source(energy=ValueError)
+    with pytest.raises(SourceSpecificationError) as e:
+        photons = s.generate_photons(5)
+    assert '`polarizarion` must be' in str(e.value)

--- a/marxs/test/test_src_mir_det.py
+++ b/marxs/test/test_src_mir_det.py
@@ -17,7 +17,7 @@ def test_src_mir_det():
 						  [0, 1, 0],
 						  [-1, 0, 0]])
 
-	source = LabConstantPointSource([10., 0., 0.], -1., 100., -1.)
+	source = LabConstantPointSource([10., 0., 0.], flux=100., energy=-1.)
 	mirror = MultiLayerMirror(string1, string2, position=np.array([0., 0., 0.]), orientation=rotation1)
 	detector = FlatDetector(1., position=np.array([0., 0., 10.]), orientation=rotation2, zoom = np.array([1, 100, 100]))
 


### PR DESCRIPTION
The general source now has very general ability to sample time, energy and polarization
from arrays, number, functions etc.
Thus, several of the derived sources are now a lot shorter. This also required renaming some
arguments, so a lot of the tests had to be adapted.

@jhfrost314 All tests pass again, but getting it do do that was a lot more work than I anticipated. I'm not quite done yet (tests and docs are missing), but please start to review and comment if you have time. I might continue to work on this over the weekend and if I'm satisfied, I might merge it, even if I've not heard from you.

The point is that I've changed almost every file that has something to do with sources (and many of the tests have) and I've also changed some of the calling signatures of your source. I call "rate" not "flux". Also I discovered, that your sources accepted a "polarization" keyword that was not used in the code, so I removed it.

Again, I would really like to wait for you to comment on this before I merge, but I also don't want to wait for too long because I can hardly work on anything else before this is merged without risking merge conflicts.