### PR TITLE
Make NOT install MARX C code the default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ install:
   - pip install transforms3d
   - pip install alabaster --upgrade
   # Set the location the MARX c code and compiled version in setup.cfg
-  - sed -e s/'srcdir ='/'srcdir = \/home\/travis\/build\/Chandra-MARX\/marxs\/marx-5\.1\.0\/'/g setup.cfg
-  - sed -e s/'libdir ='/'libdir = \/home\/travis\/build\/Chandra-MARX\/marxs\/marx\/lib\/'/g setup.cfg
+  - sed -i.bak s/'srcdir ='/'srcdir = \/home\/travis\/build\/Chandra-MARX\/marxs\/marx-5\.1\.0\/'/g setup.cfg
+  - sed -i.bak s/'libdir ='/'libdir = \/home\/travis\/build\/Chandra-MARX\/marxs\/marx\/lib\/'/g setup.cfg
   - python setup.py install
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ install:
   - source activate test-environment
   - pip install transforms3d
   - pip install alabaster --upgrade
+  # Set the location the MARX c code and compiled version in setup.cfg
+  - sed -e s/'srcdir ='/'srcdir = \/home\/travis\/build\/Chandra-MARX\/marxs\/marx-5\.1\.0\/'/g setup.cfg
+  - sed -e s/'libdir ='/'libdir = \/home\/travis\/build\/Chandra-MARX\/marxs\/marx\/lib\/'/g setup.cfg
   - python setup.py install
 
 matrix:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,10 +6,40 @@ Installation
 
 `classic marx`_ C code
 ======================
+The `classic marx`_ code is an optional dependency. By default, it is not used and all
+modules build on `classic marx`_ will be unavailable.
+
 In order to build the interface to the `classic marx`_ C code, you need to set the path
 to both, the `classic marx`_ source code and an installed version of `classic marx`_ on your
 machine in the ``setup.cfg`` file in the root directory of the installation
 package.
+
+These are the steps required to use the interface to `classic marx`_:
+
+- Edit ``setup.cfg`` with the path to the `classic marx`_ source code and to compiled binaries.
+- Once that is done, install marxs with ``python setup.py install`` in the root directory of the MARXS distribution.
+
+In the current (`classic marx`_ 5.1) default setup, `classic marx`_ compiles static libraries, not
+shared objects. Static libraries are a tiny bit better in performance at the
+cost of extra difficulty of linking them into shared objects. Since `classic marx`_ is
+not meant to be used a library for external functions (like this python
+module), the default installation settings are tuned for performance.
+On some architectures (tested on 32-bit Ubuntu GNU/Linux) linking the static
+libraries works, on other you might see an error like this::
+
+    relocation R_X86_64_32 against `.text' can not be used when making a shared object; recompile with -fPIC
+
+In that case, simply recompile and install `classic marx`_ as *P* osition *I* ndependent
+*C* ode. In the `classic marx`_ source code directory:: 
+
+    make distclean
+    ./configure --prefix=/path/to/your/instalation/ CFLAGS="-O2 -g -fPIC"
+    make
+    make install
+
+I promise that the performance difference is so small, you won't notice
+it when you run the classic `classic marx`_ version, but it allows the setup process of
+this python module to compile the interface to use those libraries.
 
 If you are a developer, you might want to tell git to ignore the local path
 that you put into ``setup.cfg`` to avoid committing and pushing that to the
@@ -20,31 +50,3 @@ repro accidentially::
 (However, note that this will make some manual fixing necessary if the upstream
 ``setup.cfg`` changes, e.g. because we decide to add a new option. See 
 ``git help update-index`` for more explanation.)
-
-.. todo::
-   Implement a mechanism where `classic marx`_ is downloaded and installed in the
-   installation process to a known location, possibly to extern in this
-   package?
-   (E.g. make it a git submodule?) and bootstrap it into the installation process?
-
-In the current (`classic marx`_ 5.1) default setup, `classic marx`_ compiles static libraries, not
-shared objects. Static libraries are a tiny bit better in performance at the
-cost of extra difficulty of linking them into shared objects. Since `classic marx`_ is
-not meant to be used a library for external functions (like this python
-module), the default installations settings are tuned for performance.
-On some architectures (tested on 32-bit Ubuntu GNU/Linux) linking the static
-libraries works, on other you might see an error like this::
-
-    relocation R_X86_64_32 against `.text' can not be used when making a shared object; recompile with -fPIC
-
-In that case, simply recompile and install `classic marx`_ as *P* osition *I* ndependent
-*C* ode. In the `classic marx`_ source code directory:: 
-
-    make distclean
-    ./configure --prefix=/melkor/d1/guenther/marx/dev CFLAGS="-O0 -g -fPIC"
-    make
-    make install
-
-I promise that the performance difference is so small, you won't notice
-it when you run the classic `classic marx`_ version, but it allows the setup process of
-this python module to compile the interface to use those libraries.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,17 +1,19 @@
 [MARX]
 
-# The local path to the marx source code goes here
-#srcdir = /melkor/d1/guenther/marx/dist/
-# The local path to a compiled version of marx goes here
+# The local path to the marx source code and a compiled version goes here
 # Careful: Compile as shared library or with -fPIC
+# If left empty, the MARX C code is not going to be available
+# See installation instruction for details
+srcdir =
+libdir =
+
+
+# Examples could be
+#srcdir = /melkor/d1/guenther/marx/dist/
 #libdir = /melkor/d1/guenther/marx/dev/lib/
 
 #srcdir = /Users/hamogu/code/marx/
 #libdir = /Users/hamogu/marx/devPIC/lib/
-
-srcdir = /home/travis/build/Chandra-MARX/marxs/marx-5.1.0/
-libdir = /home/travis/build/Chandra-MARX/marxs/marx/lib/
-
 
 [build_sphinx]
 source-dir = docs

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import sys
 # To use a consistent encoding
 from codecs import open
 from os import path
+from ConfigParser import ConfigParser, NoOptionError
 
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
@@ -11,11 +14,6 @@ from sphinx.setup_command import BuildDoc
 import versioneer
 
 
-### import DESCRIPTION file ###
-here = path.abspath(path.dirname(__file__))
-# Get the long description from the relevant file
-with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
-    long_description = f.read()
 
 ### versioneer ###
 versioneer.VCS = 'git'
@@ -48,20 +46,19 @@ cmdclass = versioneer.get_cmdclass()
 cmdclass['test'] = PyTest
 cmdclass['build_sphinx'] = BuildDoc
 
+setup_args = {
+    'name': 'marxs',
+    'description': 'Multi Architecture Raytracer for X-ray satellites',
+    'author': 'MIT / H. M. Guenther',
+    'author_email': 'hgunther@mit.edu',
 
-setup(name='marxs',
-      description='Multi Architecture Raytracer for X-ray satellites',
-      long_description=long_description,
-      author='H. M. Guenther',
-      author_email='hgunther@mit.edu',
+    'version': versioneer.get_version(),
+    'cmdclass': cmdclass,
 
-      version=versioneer.get_version(),
-      cmdclass=cmdclass,
+    'license': 'GPLv3+',
 
-      license='GPLv3+',
-
-      # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-      classifiers=[
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    'classifiers': [
         # How mature is this project? Common values are
         # 3 - Alpha
         # 4 - Beta
@@ -78,11 +75,43 @@ setup(name='marxs',
         'Programming Language :: Python :: 2.7',
         ],
 
-      packages = find_packages(),
+    'packages': find_packages(),
+    # to be done  - or use astropy template?
+    # package_data = {
+    #     # If any package contains *.txt or *.rst files, include them:
+    #     '': ['*.txt', '*.rst'],
+    #     # And include any *.msg files found in the 'hello' package, too:
+    #     'hello': ['*.msg'],
+    # },
 
-      setup_requires=["cffi>=1.0.0", "astropy>=1.0", "transforms3d"],
-      cffi_modules=["marxs/optics/marx_build.py:ffi"],
-      install_requires=["cffi>=1.0.0"],
-      tests_require=['pytest'],
-      zip_safe=False,
-     )
+    'setup_requires': ["astropy>=1.0", "transforms3d"],
+    'install_requires': [],
+    'tests_require': ['pytest'],
+    'zip_safe': False,
+    }
+### import DESCRIPTION file ###
+here = path.abspath(path.dirname(__file__))
+# Get the long description from the relevant file
+with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
+    setup_args['long_description'] = f.read()
+
+
+
+# check is MARX C code is configured in setup.py and if it is, add to
+# appropriate arguments to setup args
+conf = ConfigParser()
+conf.read('setup.cfg')
+try:
+    marxscr = conf.get('MARX', 'srcdir')
+    marxlib = conf.get('MARX', 'libdir')
+    if marxscr and marxlib:
+        setup_args['cffi_modules'] = ["marxs/optics/marx_build.py:ffi"]
+        setup_args['install_requires'].append("cffi>=1.0.0")
+        setup_args['setup_requires'].append("cffi>=1.0.0")
+        print('Using MARX C code at {0}\n and compiled libraries at {1}'.format(marxscr, marxlib))
+    else:
+       print('MARX C code is not configured in setup.cfg - modules will be disabled.')
+except NoOptionError:
+   print('MARX C code is not configured in setup.cfg - modules will be disabled.')
+
+setup(**setup_args)


### PR DESCRIPTION
update installations instructions
update Travis to link to MARX C code, although that's not the default.
At this time it's required for many tests.

closes #1 