### PR TITLE
sphinx build is broken

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,8 +53,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
     'matplotlib.sphinxext.plot_directive',
-    'IPython.sphinxext.ipython_directive',
-    'IPython.sphinxext.ipython_console_highlighting',
 ]
 
 numpydoc_show_class_members = False

--- a/docs/pyplots/sourcespectrum.py
+++ b/docs/pyplots/sourcespectrum.py
@@ -1,0 +1,27 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from astropy.table import Table
+from marxs.source.source import Source
+en = np.arange(0.5, 7., .5)
+flux = en**(-2)
+
+# Input as dictionary
+dictspectrum = {'energy': en, 'flux': flux}
+s1 = Source(energy=dictspectrum, name='dict')
+
+# Input as astropy Table
+tablespectrum = Table([en, flux], names=['energy', 'flux'])
+s2 = Source(energy=tablespectrum, name='table')
+
+# Input as numpy arrays
+numpyspectrum = np.vstack([en, flux])
+s3 = Source(energy=numpyspectrum, name='2d array')
+
+fig = plt.figure()
+for s in [s1, s2, s3]:
+    photons = s.generate_photons(1e3)
+    plt.hist(photons['energy'], histtype='step', label=s.name, bins=20)
+
+leg = plt.legend()
+lab = plt.xlabel('Energy [keV]')
+lab = plt.ylabel('Counts / bin')

--- a/docs/source.rst
+++ b/docs/source.rst
@@ -83,45 +83,9 @@ Similarly to the flux, the input for ``energy`` can just be a number, which spec
 
 We can also specify a spectrum, by giving binned energy and flux density values. The energy values are taken as the *upper* egde of the bin; the first value of the flux density array is ignored since the lower bound for this bin is undefined. The spectrum can either be in the form of a (2, N) `numpy.ndarray` or it can be some type of table, e.g. an `astropy.table.Table` or a `dict <dict>` with columns named "energy" and "flux" (meaning: "flux density" in counts/s/unit area/keV). In the following exmaple, we specify the same spectrum in three differect ways (the plot looks a little different, because photon energies are randomly drawn from the spectrum, so there is a Poisson uncertainty):
 
-.. ipython::
+.. plot:: pyplots/sourcespectrum.py
+   :include-source:
 
-   In [448]:    import numpy as np
-
-   In [449]:    import matplotlib.pyplot as plt
-
-   In [450]:    from astropy.table import Table
-
-   In [451]:    from marxs.source.source import Source
-
-   In [452]:    en = np.arange(0.5, 7., .5)
-
-   In [453]:    flux = en**(-2)
-
-   In [454]:    dictspectrum = {'energy': en, 'flux': flux}
-
-   In [455]:    s1 = Source(energy=dictspectrum, name='dict')
-
-   In [456]:    tablespectrum = Table([en, flux], names=['energy', 'flux'])
-
-   In [457]:    s2 = Source(energy=tablespectrum, name='table')
-
-   In [458]:    numpyspectrum = np.vstack([en, flux])
-
-   In [459]:    s3 = Source(energy=numpyspectrum, name='2d array')
-
-   In [460]:    fig = plt.figure()
-
-   In [461]:    for s in [s1, s2, s3]:
-      .....:            photons = s.generate_photons(1e3)
-      .....:            plt.hist(photons['energy'], histtype='step', label=s.name, bins=20)
-      .....:     
-
-   In [462]:    leg = plt.legend()
-
-   In [463]:    lab = plt.xlabel('Energy [keV]')
-
-   @savefig histograms.png width=6in align=center
-   In [464]:    lab = plt.ylabel('Counts / bin')
 
 If the input spectrum is in some type of file, e.g. fits or ascii, the `astropy.table.Table` `read/write interface <https://astropy.readthedocs.org/en/stable/io/unified.html>`_ offers a convenient way to read it into python:
 


### PR DESCRIPTION
RTDs does not find the IPython extentions and when I run it locally it fails with
```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/Users/hamogu/anaconda/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/Users/hamogu/anaconda/lib/python2.7/site-packages/IPython/core/interactiveshell.py", line 3394, in atexit_operations
    self.history_manager.end_session()
  File "/Users/hamogu/anaconda/lib/python2.7/site-packages/IPython/core/history.py", line 547, in end_session
    len(self.input_hist_parsed)-1, self.session_number))
OperationalError: attempt to write a readonly database
Error in sys.exitfunc:
Traceback (most recent call last):
  File "/Users/hamogu/anaconda/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/Users/hamogu/anaconda/lib/python2.7/site-packages/IPython/core/interactiveshell.py", line 3394, in atexit_operations
    self.history_manager.end_session()
  File "/Users/hamogu/anaconda/lib/python2.7/site-packages/IPython/core/history.py", line 547, in end_session
    len(self.input_hist_parsed)-1, self.session_number))
sqlite3.OperationalError: attempt to write a readonly database
```

Maybe it's the easiest rewrite the one example that uses that format to plain python.