### PR TITLE
clean up e_z <-> e_y issues in gratings

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -29,4 +29,4 @@ Developer time is more valuable than CPU time.
 
 Order of optical elements is known.
   MARXS assumes that the order in which photons hit (or miss)
-  optical elements in know a-priory, e.g. entrance aperture to mirror to grating to detector.
+  optical elements is known, e.g. entrance aperture to mirror to grating to detector.

--- a/marxs/optics/grating.py
+++ b/marxs/optics/grating.py
@@ -148,7 +148,9 @@ class FlatGrating(FlatOpticalElement):
         p : np.array
             Array of Eucleadian direction vectors
         '''
-        return 1
+        # -1 because n, l, d should be right-handed coordinate system
+        # while n = e_x, l = e_x, and d = e_y would be left-handed.
+        return -1
 
     def __init__(self, **kwargs):
         self.order_selector = kwargs.pop('order_selector')
@@ -169,7 +171,8 @@ class FlatGrating(FlatOpticalElement):
         p = norm_vector(h2e(photons['dir'].data[intersect]))
         n = self.geometry['plane'][:3]
         l = h2e(self.geometry['e_groove'])
-        d = h2e(self.geometry['e_perp_groove'])
+        # Minus sign here because we want n, l, d to be a right-handed coordinate system
+        d = -h2e(self.geometry['e_perp_groove'])
 
         wave = energy2wave / photons['energy'].data[intersect]
         # calculate angle between normal and (ray projected in plane perpendicular to groove)
@@ -218,7 +221,8 @@ class CATGrating(FlatGrating):
         Blazing happens on the side of the negative orders. Obviously, this
         convention is only meaningful if the photons do not arrive perpendicular to the grating.
         '''
-        d = h2e(self.geometry['e_z'])
+        # Minus sign here because we want n, l, d to be a right-handed coordinate system
+        d = -h2e(self.geometry['e_perp_groove'])
         dotproduct = np.dot(p, d)
         sign = np.sign(dotproduct)
         sign[sign == 0] = 1

--- a/marxs/optics/tests/test_grating.py
+++ b/marxs/optics/tests/test_grating.py
@@ -190,26 +190,27 @@ def test_order_convention():
 
 
 def test_CAT_order_convention():
-    dirs = np.zeros((3, 4))
-    dirs[:, 0] = -1.
-    dirs[1, 2]= 0.01
-    dirs[2, 2]= -0.01
-    photons = Table({'pos': np.ones((3, 4)),
+    dirs = np.array([[-1, 0., 0., 0],
+                     [-1, 0.01, -0.01, 0],
+                     [-1, 0.01, 0.01, 0],
+                     [-1, -0.01, 0.01, 0],
+                     [-1, -0.01, -0.01, 0]])
+    photons = Table({'pos': np.ones((5, 4)),
                      'dir': dirs,
-                     'energy': np.ones(3),
-                     'polarization': np.ones(3),
-                     'probability': np.ones(3),
+                     'energy': np.ones(5),
+                     'polarization': np.ones(5),
+                     'probability': np.ones(5),
                      })
     gp = CATGrating(d=1./5000, order_selector=constant_order_factory(5), zoom=2)
     p5 = gp.process_photons(photons.copy())
     gm = CATGrating(d=1./5000, order_selector=constant_order_factory(-5), zoom=2)
     m5 = gm.process_photons(photons.copy())
     for g in [gm, gp]:
-        assert np.all(g.order_sign_convention(h2e(photons['dir'])) == np.array([1, 1, -1]))
-    assert p5['dir'][1, 1] > 0
-    assert p5['dir'][2, 1] < 0
-    assert m5['dir'][1, 1] < 0
-    assert m5['dir'][2, 1] > 0
+        assert np.all(g.order_sign_convention(h2e(photons['dir'])) == np.array([1, -1, -1, 1, 1]))
+    assert np.all(p5['dir'][1:3, 1] > 0)
+    assert np.all(p5['dir'][3:, 1] < 0)
+    assert np.all(m5['dir'][1:3, 1] < 0)
+    assert np.all(m5['dir'][3:, 1] > 0)
 
 
 def test_uniform_efficiency_factory():

--- a/marxs/tests/test_analysis.py
+++ b/marxs/tests/test_analysis.py
@@ -51,7 +51,7 @@ def test_resolvingpower_consistency():
     # are defined the same way for all gratings in the GAS.
     blazeang = 1.91
     rowland = RowlandTorus(6000., 6000.)
-    blazemat = transforms3d.axangles.axangle2mat(np.array([0, 1, 0]), np.deg2rad(blazeang))
+    blazemat = transforms3d.axangles.axangle2mat(np.array([0, 0, 1]), np.deg2rad(blazeang))
     gas = GratingArrayStructure(rowland=rowland, d_element=30.,
                                 x_range=[1e4, 1.4e4],
                                 radius=[50, 100],


### PR DESCRIPTION
Commit 3ba95601e9a17b681e9681987a05f030abdf42b3
changed the default dispersion direction to e_y in the global coordinate system.
This required changes in the coordiante system used in the dispersion equation,
which incidentially turned a right-handed int oa left-handed coordinate system.
A lot of sign error in the direction of positive/negative orders are the result.
Those where not caught, because expected values in the tests were not updated
and tests did not include enough variability in the nuiscance direction
(rays with a commponent alnog the grooves).