### PR TITLE
Fix but in intersect for Circular detector

### DIFF
--- a/marxs/optics/detector.py
+++ b/marxs/optics/detector.py
@@ -186,7 +186,7 @@ class CircularDetector(OpticalElement):
             phi = np.arctan2(xy_p[:, 1], xy_p[:, 0])
             # Shift phi by offset, then wrap to that it is in range [-pi, pi]
             interpos_local[i, 0] = (phi - self.phi_offset + np.pi) % (2 * np.pi) - np.pi
-             # Those look like they hit in the xy plane.
+            # Those look like they hit in the xy plane.
             # Still possible to miss if z axis is too large.
             # Calculate z-coordiante at intersection
             interpos_local[intersect, 1] = xyz[i, 2] + apick * dir[i, 2]
@@ -195,10 +195,14 @@ class CircularDetector(OpticalElement):
             interpos[i, 3] = 1
             # set those elements on intersect that miss in z to False
             trans, rot, zoom, shear = decompose44(self.pos4d)
-            z_p = interpos[intersect, 2]
-            intersect[intersect.nonzero()[0][np.abs(z_p) > zoom[2]]] = False
-            # Now reset everything to nan that is not intersect
+            z_p = interpos[i, 2]
+            intersect[i.nonzero()[0][np.abs(z_p) > 1]] = False
+            # Now reset everything to nan that does not intersect
             interpos_local[~i, :] = np.nan
+            # interpos_local in z direction is in local coordinates, i.e.
+            # the x coordiante is 0..1, but we want that in units of the
+            # global coordinate system.
+            interpos_local[:, 1] = interpos_local[:, 1] * zoom[2]
             interpos[~i, :] = np.nan
 
             interpos = np.dot(self.pos4d, interpos.T).T

--- a/marxs/optics/tests/test_detector.py
+++ b/marxs/optics/tests/test_detector.py
@@ -64,6 +64,21 @@ def test_intersect_tube_miss():
     assert np.all(np.isnan(interpos))
     assert np.all(np.isnan(inter_local))
 
+def test_intersect_tube_hitmiss_zoomed():
+    '''Rays that hit a one tube, but miss a shorter one'''
+    dir = np.array([[-.1, 0., 0., 0], [1., 0, -0.2, 0.]])
+    pos = np.array([[20., 0., 0.8, 1.], [2., .0, 0.4, 1.]])
+
+    circ = CircularDetector(zoom=[1, 1, 1])
+    intersect, interpos, inter_local = circ.intersect(dir, pos)
+    assert np.all(intersect == True)
+
+    circ = CircularDetector(zoom=[1, 1, .5])
+    intersect, interpos, inter_local = circ.intersect(dir, pos)
+    assert np.all(intersect == False)
+    assert np.all(np.isnan(interpos))
+    assert np.all(np.isnan(inter_local))
+
 def test_intersect_tube_2points():
     dir = np.array([[-.1, 0., 0., 0], [-0.5, 0, 0., 0.], [-1., 0., 0., 0.]])
     pos = np.array([[50., 0., 0., 1.], [10., .5, 0., 1.], [2, 0, .3, 1.]])
@@ -76,7 +91,26 @@ def test_intersect_tube_2points():
                                                 [-1, 0., .3]]))
     assert np.allclose(inter_local, np.array([[0., -np.arcsin(0.5), 0.],
                                               [0., 0., 0.3]]).T)
-    # now hit the outside. Looks very similar, if we remove the phi_offset, too.
+
+def test_intersect_tube_2points_zoomed():
+    '''inter_local should be the same if we make the tube longer in z'''
+    dir = np.array([[-.1, 0., 0., 0], [-0.5, 0, 0., 0.], [-1., 0., 0., 0.]])
+    pos = np.array([[50., 0., 0., 1.], [10., .5, 0., 1.], [2, 0, .3, 1.]])
+
+    circ = CircularDetector(phi_offset=-np.pi, zoom=[1, 1., 5.])
+    intersect, interpos, inter_local = circ.intersect(dir, pos)
+    assert np.all(intersect == True)
+    assert np.allclose(h2e(interpos), np.array([[-1., 0., 0.],
+                                                [-np.sqrt(0.75), 0.5, 0.],
+                                                [-1, 0., .3]]))
+    assert np.allclose(inter_local, np.array([[0., -np.arcsin(0.5), 0.],
+                                              [0., 0., 0.3]]).T)
+
+def test_intersect_tube_2points_outside():
+    '''Now hit the outside. Looks very similar, if we remove the phi_offset, too.'''
+    dir = np.array([[-.1, 0., 0., 0], [-0.5, 0, 0., 0.], [-1., 0., 0., 0.]])
+    pos = np.array([[50., 0., 0., 1.], [10., .5, 0., 1.], [2, 0, .3, 1.]])
+
     circ = CircularDetector(inside=False)
     intersect, interpos, inter_local = circ.intersect(dir, pos)
     assert np.all(intersect == True)
@@ -86,8 +120,10 @@ def test_intersect_tube_2points():
     assert np.allclose(inter_local, np.array([[0., np.arcsin(0.5), 0.],
                                               [0., 0., 0.3]]).T)
 
-    # Repeat with a tube that's moved and zoomed to make sure we did not mess up local and
-    # global coordinates in the implementation
+def test_intersect_tube_2points_translation():
+    '''Repeat with a tube that's moved and zoomed to make sure we
+    did not mess up local and global coordinates in the implementation
+    '''
     circ = CircularDetector(position=[0.8, 0.8, 1.2], zoom=[1, 1, 2])
     intersect, interpos, inter_local = circ.intersect(np.array([[1., 0., .0, 0],
                                                                 [1., 0., 0., 0.]]),


### PR DESCRIPTION
intersect works in local coordinates, thus a zoom in z is already taken out by that
transformation. We need to do two things:
- hit/miss in z is in the range [-1, 1]
- local_coos output should be in units of global system, so need to apply zoom to
  z-coordinate (but not the other local coo, which is an angle).