### PR TITLE
Fix handling of probabilities

### DIFF
--- a/marxs/optics/filter.py
+++ b/marxs/optics/filter.py
@@ -44,7 +44,7 @@ class GlobalEnergyFilter(OpticalElement):
         p =  self.filterfunc(photons['energy'])
         if np.any(p < 0.) or np.any(p > 1.):
             raise ValueError('Probabilities returned by filterfunc must be in interval [0, 1].')
-        photons['probability'] = p
+        photons['probability'] *= p
         return photons
 
 

--- a/marxs/optics/tests/test_filter.py
+++ b/marxs/optics/tests/test_filter.py
@@ -10,9 +10,10 @@ def test_energydependentfilter(filterclass):
     # Useless filter function, but good for testing
     f = filterclass(filterfunc=lambda x: 1./x)
     photons = generate_test_photons(5)
+    photons['probability'] = 0.8
     photons['energy'] = np.arange(1., 6.)
     photons = f(photons)
-    assert np.allclose(photons['probability'] , 1./np.arange(1., 6.))
+    assert np.allclose(photons['probability'] , 0.8 / np.arange(1., 6.))
 
 @pytest.mark.parametrize("filterclass", [EnergyFilter, GlobalEnergyFilter])
 def test_energyfilter_error(filterclass):


### PR DESCRIPTION
A bug was discovered by comparing MARXS simulations against EXCEL spreadsheets
by Randall Smith, where MARXS would give a probability for each photon that is too high.

It turns out that some filter elements did not multiply the input probability with
the filtercurve, but replaced it with the filter curve.
The fix that that is, in essence, to replace "p = p_elem" with "p *= p_elem".

This commit also add several regression tests for filters and other optical elements to
prevent this kind of mistake in the future.