### PR TITLE
Prevent doubling of header keywords

### DIFF
--- a/marxs/optics/aperture.py
+++ b/marxs/optics/aperture.py
@@ -1,5 +1,6 @@
 import numpy as np
-from astropy.table import Column, vstack
+from astropy import table
+from astropy.utils.metadata import enable_merge_strategies
 
 from .base import FlatOpticalElement
 from ..base import GeometryError
@@ -7,6 +8,7 @@ from ..visualization.utils import plane_with_hole, get_color
 from ..math.pluecker import h2e
 from ..math.utils import anglediff
 from ..simulator import BaseContainer
+from .. import utils
 
 class BaseAperture(object):
     '''Base Aperture class'''
@@ -17,7 +19,7 @@ class BaseAperture(object):
     @staticmethod
     def add_colpos(photons):
         '''add columns ['pos'] to photon array'''
-        photoncoords = Column(name='pos', length=len(photons), shape=(4,))
+        photoncoords = table.Column(name='pos', length=len(photons), shape=(4,))
         photons.add_column(photoncoords)
         photons['pos'][:, 3] = 1
 
@@ -268,5 +270,7 @@ class MultiAperture(BaseAperture, BaseContainer):
             for p in self.postprocess_steps:
                 p(thisphot)
             outs.append(thisphot)
-        photons = vstack(outs)
+        with enable_merge_strategies(utils.MergeIdentical):
+            photons = table.vstack(outs)
+
         return photons

--- a/marxs/simulator/simulator.py
+++ b/marxs/simulator/simulator.py
@@ -181,7 +181,7 @@ class Parallel(BaseContainer):
 
     Examples
     --------
-    In this example we build up a detector made up of four CCD. Each CCD is 10 mm * 10 mm
+    In this example we build up a detector made up of four CCDs. Each CCD is 10 mm * 10 mm
     large and has a pixel size of 0.01 mm. The CCDs are set in a square with small spaces
     in between.
 

--- a/marxs/utils.py
+++ b/marxs/utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 from astropy.table import Table
+from astropy.utils.metadata import MergeStrategy
 
 def generate_test_photons(n=1):
     '''Generate a photon structure for testing.
@@ -33,3 +34,22 @@ def generate_test_photons(n=1):
                      'probability': np.ones(n),
                      })
     return photons
+
+
+class MergeIdentical(MergeStrategy):
+    '''Merge metadata in astropy table
+
+    In some cases, a table of photons is split up, e.g. when half of
+    the photons passes through one aperture and the other half through
+    a second aperture. When merging those tables back together, they
+    have the same metadata, but the default `astropy.utils.metadata.MergePlus`
+    would lead to doubled entries.
+    '''
+    types = [(list, list), (tuple, tuple)]
+
+    @classmethod
+    def merge(cls, left, right):
+        if left == right:
+            return left
+        else:
+            return left + right


### PR DESCRIPTION
Bug: When photons tables are merged, their metadata is added together.
MultiAperture splits the photon list and stacks it back together, thus
creating copies of the metadata. This is annoying, because the fits writer cannot
use tuples or arbitrary lengths as header keywords.