### PR TITLE
For some range of angles the orientation of elements on the Rowland circle is off

### DIFF
--- a/marxs/base/base.py
+++ b/marxs/base/base.py
@@ -40,9 +40,10 @@ class DocMeta(type):
             # for items that have a docstring (i.e. methods) that is empty
             if hasattr(dict[k], '__doc__') and dict[k].__doc__ is None:
                 for b in mro:
-                    # look if has defines the method
+                    # look if this b defines the method
                     # (it might not in case of multiple inheritance)
-                    if hasattr(b, k):
+                    if hasattr(b, k) and (getattr(b, k).__doc__ is not None):
+                        # copy docstring if super method has one
                         dict[k].__doc__ = getattr(b, k).__doc__
                         break
 

--- a/marxs/design/rowland.py
+++ b/marxs/design/rowland.py
@@ -395,13 +395,14 @@ class ElementPlacementError(Exception):
 class RowlandCircleArray(ParallelCalculated, OpticalElement):
     '''A 1D collection of elements (e.g. CCDs) arranged on a Rowland circle.
 
-    When a `LinearCCDArray` is initialized, it places a number of elements on the
+    When a `RowlandCircleArray` is initialized, it places a number of elements on the
     Rowland circle. These elements could be any optical element, but the most
     common use for this structure is an array of CCDs capturing a spread-out
     grating spectrum like ACIS-S in Chandra.
 
     After generation, individual positions can be adjusted by hand by
-    editing the attributes `elem_pos` or `elem_uncertainty`. See `Parallel` for details.
+    editing the attributes `elem_pos` or `elem_uncertainty`.
+    See `marxs.simulator.Parallel` for details.
 
     After any of the `elem_pos`, `elem_uncertainty` or
     `uncertainty` is changed, `generate_elements` needs to be

--- a/marxs/design/rowland.py
+++ b/marxs/design/rowland.py
@@ -234,7 +234,7 @@ class RowlandTorus(MarxsElement):
         Returns
         -------
         gradient : np.array
-            Gradient vector field in euklidean coordinates. One vector corresponds to each
+            Gradient vector field in homogeneous coordinates. One vector corresponds to each
             input point. The shape of ``gradient`` is the same as the shape of ``xyz``.
         '''
         if not ((theta.ndim == 1) and (phi.ndim == 1)):
@@ -244,10 +244,10 @@ class RowlandTorus(MarxsElement):
         normal[:, 1] = np.sin(theta)
         normal[:, 2] = np.cos(theta) * np.sin(phi)
 
-        return h2e(np.einsum('...ij,...j', self.pos4d, e2h(normal, 0)))
+        return np.einsum('...ij,...j', self.pos4d, e2h(normal, 0))
 
 
-    def normal(self, xyz):
+    def normal(self, xyzw):
         '''Return the gradient vector field.
 
         Following the usual concentions, the vector is pointing outwards
@@ -255,7 +255,7 @@ class RowlandTorus(MarxsElement):
 
         Parameters
         ----------
-        xyz : np.array of shape (N, 3) or (3)
+        xyzw : np.array of shape (N, 4) or (4)
             Coordinates of points in euklidean space. The quartic is calculated for
             those points. All points need to be on the surface of the torus.
 
@@ -265,7 +265,7 @@ class RowlandTorus(MarxsElement):
             Gradient vector field in euklidean coordinates. One vector corresponds to each
             input point. The shape of ``gradient`` is the same as the shape of ``xyz``.
         '''
-        theta, phi = self.xyzw2parametric(e2h(xyz, 1))
+        theta, phi = self.xyzw2parametric(xyzw, 1)
         return self.normal_parametric(theta, phi)
 
     def xyz_from_radiusangle(self, radius, angle, interval):
@@ -470,7 +470,7 @@ class RowlandCircleArray(ParallelCalculated, OpticalElement):
         super(RowlandCircleArray, self).__init__(**kwargs)
 
     def rowland_normal(self, xyzw):
-        return self.rowland.normal(h2e(xyzw))
+        return self.rowland.normal(xyzw)
 
     def xyzwpos(self):
         radii = self.distribute_elements_on_arc()
@@ -581,7 +581,7 @@ class LinearCCDArray(ParallelCalculated, OpticalElement):
         super(LinearCCDArray, self).__init__(**kwargs)
 
     def rowland_normal(self, xyzw):
-        return self.rowland.normal(h2e(xyzw))
+        return self.rowland.normal(xyzw)
 
     def xyz_from_radiusangle(self, r, phi, x_range):
         '''Wrap `marxs.design.RowlandTorus.xyz_from_radiusangle` for better error message'''
@@ -773,7 +773,7 @@ class GratingArrayStructure(LinearCCDArray):
 
             # Find the rotation between [1, 0, 0] and the new normal
             # Keep grooves (along e_y) parallel to e_y
-            rot_mat = ex2vec_fix(normals[i, :], parallels[i, :])
+            rot_mat = ex2vec_fix(h2e(normals[i, :]), h2e(parallels[i, :]))
 
             pos4d.append(transforms3d.affines.compose(h2e(xyzw[i, :]), rot_mat, np.ones(3)))
         return pos4d

--- a/marxs/design/rowland.py
+++ b/marxs/design/rowland.py
@@ -186,7 +186,68 @@ class RowlandTorus(MarxsElement):
         torus = np.array([x, y, z, w]).T
         return np.einsum('...ij,...j', self.pos4d, torus)
 
-    def normal(self, xyz, origin=np.array([-1., 0, 0])):
+    def xyzw2parametric(self, xyzw, transform=True):
+        '''Calculate (theta, phi) coordinates for point on torus surface.
+
+        Parameters
+        ----------
+        xyzw : np.array of shape (N, 4)
+            Coordinates of points on the torus surface in homogeneous coordiantes.
+
+        transform : bool
+            If ``True`` transform ``xyz`` from the global coordinate system into the
+            local coordinate system of the torus. If this transformation is done in the
+            calling function already, set to ``False``.
+
+        Returns
+        -------
+        theta, phi: np.array
+            Parametric representation for all points on the torus.
+        '''
+        if transform:
+            invpos4d = np.linalg.inv(self.pos4d)
+            xyzw = np.einsum('...ij,...j', invpos4d, xyzw)
+
+        xyz = h2e(xyzw)
+
+        if not np.allclose(self.quartic(xyz, transform=False) / self.R**4., 0.):
+            raise ValueError('Parametric representation is only defined for points on torus surface.')
+        # There are two branches and we can use the sign to distinguish between them
+        s = np.sign(np.sqrt(xyz[:,0]**2 + xyz[:, 2]**2) - self.R)
+        theta = np.arcsin(s * xyz[:, 1] / self.r) + (s < 0) * np.pi
+
+        phi = np.arctan2(xyz[:, 2], xyz[:, 0])
+
+        return theta, phi
+
+    def normal_parametric(self, theta, phi):
+        '''Return the gradient vector field.
+
+        Following the usual concentions, the vector is pointing outwards
+        of the torus volume.
+
+        Parameters
+        ----------
+        theta, phi : 1-d np.arrays
+            Theta and phi coordinates for points on the torus surface.
+
+        Returns
+        -------
+        gradient : np.array
+            Gradient vector field in euklidean coordinates. One vector corresponds to each
+            input point. The shape of ``gradient`` is the same as the shape of ``xyz``.
+        '''
+        if not ((theta.ndim == 1) and (phi.ndim == 1)):
+            raise ValueError('theta and phi must be 1-d arrays.')
+        normal = np.empty((len(theta), 3))
+        normal[:, 0] = np.cos(theta) * np.cos(phi)
+        normal[:, 1] = np.sin(theta)
+        normal[:, 2] = np.cos(theta) * np.sin(phi)
+
+        return h2e(np.einsum('...ij,...j', self.pos4d, e2h(normal, 0)))
+
+
+    def normal(self, xyz):
         '''Return the gradient vector field.
 
         Following the usual concentions, the vector is pointing outwards
@@ -197,14 +258,6 @@ class RowlandTorus(MarxsElement):
         xyz : np.array of shape (N, 3) or (3)
             Coordinates of points in euklidean space. The quartic is calculated for
             those points. All points need to be on the surface of the torus.
-        origin : np.array or string
-            For a torus with ``r=R`` the normal at the center is ambiguous because it
-            is touched by all Rowland circles. When designing an X-ray telescope,
-            one usually considers the Rowland circle that points towards the optical
-            axis at this point. ``origin`` sets the normal to be returned for this point.
-            If ``origin="raise"`` it will raise an error instead if asked to
-            calculate an ambiguous normal.
-            This parameter has no effect to tori with ``r != R``.
 
         Returns
         -------
@@ -212,38 +265,15 @@ class RowlandTorus(MarxsElement):
             Gradient vector field in euklidean coordinates. One vector corresponds to each
             input point. The shape of ``gradient`` is the same as the shape of ``xyz``.
         '''
-        # For r,R  >> 1 even marginal differences lead to large
-        # numbers on the quartic because of R**4 -> normalize
-        invpos4d = np.linalg.inv(self.pos4d)
-        xyz = h2e(np.einsum('...ij,...j', invpos4d, e2h(xyz, 1)))
-
-        if not np.allclose(self.quartic(xyz, transform=False) / self.R**4., 0.):
-            raise ValueError('Gradient vector field is only defined for points on torus surface.')
-        factor = 4. * ((xyz**2).sum(axis=-1) + self.R**2. - self.r**2)
-        dFdx = factor * xyz[..., 0] - 8. * self.R**2 * xyz[..., 0]
-        dFdy = factor * xyz[..., 1]
-        dFdz = factor * xyz[..., 2] - 8. * self.R**2 * xyz[..., 2]
-
-        gradient = np.vstack([dFdx, dFdy, dFdz]).T
-        index = np.where(np.sum(np.abs(gradient), axis=1) == 0)[0]
-        if len(index) > 0:
-            if isinstance(origin, basestring) and (origin == "raise"):
-                raise ValueError("Ambiguous normal at {0}".format(xyz[index, :]))
-            elif len(origin) == 3:
-                for i in index:
-                    gradient[i, :] = origin
-            else:
-                raise ValueError("'origin' must be 'raise' or Eukledian vector.")
-
-        gradient = gradient / np.linalg.norm(gradient, axis=1)[:, None]
-        return h2e(np.einsum('...ij,...j', self.pos4d, e2h(gradient, 0)))
+        theta, phi = self.xyzw2parametric(e2h(xyz, 1))
+        return self.normal_parametric(theta, phi)
 
     def xyz_from_radiusangle(self, radius, angle, interval):
         '''Get Cartesian coordiantes for radius, angle on the rowland circle.
 
         y, z are calculated from the radius and angle of polar coordiantes in a plane;
         then x is determined from the condition that the point lies on the Rowland circle.
-        The plane is perpendicual to the optical axis that defines the Rowland circle.
+        The plane is perpendicular to the optical axis that defines the Rowland circle.
 
         Parameters
         ----------
@@ -253,7 +283,7 @@ class RowlandTorus(MarxsElement):
             `RowlandTorus`.
             ``angle=0`` conicides with the local y-axis.
         interval : np.array
-            [min, max] for the search. The quartic can have up to for solutions because a
+            [min, max] for the search. The quartic can have up to four solutions because a
             line can intersect a torus in four points and this interval must bracket one and only
             one solution.
 

--- a/marxs/design/tests/test_design.py
+++ b/marxs/design/tests/test_design.py
@@ -150,7 +150,7 @@ def test_torus_normal():
     t1 = mytorus.parametric(theta + 0.001, phi)
     p1 = mytorus.parametric(theta, phi + 0.001)
     t0 = mytorus.parametric(theta - 0.001, phi)
-    p0 = mytorus.parametric(theta, phi + 0.001)
+    p0 = mytorus.parametric(theta, phi - 0.001)
 
     vec_normal = mytorus.normal(h2e(xyz))
 
@@ -391,3 +391,16 @@ def test_compareRowlandCircle2LinearCCD_rotatated():
         assert np.allclose(t1, t2, rtol=1e-3, atol=0.01)
         # orientation is not too important, so allow some -1 factors
         assert np.allclose(np.abs(r1), np.abs(r2), rtol=1e-3, atol=0.01)
+
+def test_nojumpsinCCDorientation():
+    '''Regression test: CCD orientation should change smoothly along the circle.'''
+    R, r, pos4d = design_tilted_torus(12e3, 0.07, 0.15)
+    rowland = RowlandTorus(R, r, pos4d=pos4d)
+    det = RowlandCircleArray(rowland=rowland,
+                             elem_class=mock_facet,
+                             d_element=49.652, theta=[np.pi - 0.2, np.pi + 0.5])
+
+    # If all is right, this will vary very smoothly along the circle.
+    xcomponent = np.array([e.geometry['e_y'][0] for e in det.elements])
+    xcompdiff = np.diff(xcomponent)
+    assert (np.max(np.abs(xcompdiff)) / np.median(np.abs(xcompdiff))) < 1.1

--- a/marxs/design/tests/test_design.py
+++ b/marxs/design/tests/test_design.py
@@ -169,7 +169,7 @@ def test_torus_normal():
     t0 = mytorus.parametric(theta - 0.00001, phi)
     p0 = mytorus.parametric(theta, phi - 0.00001)
 
-    vec_normal = mytorus.normal(h2e(xyz))
+    vec_normal = h2e(mytorus.normal(xyz))
 
     vec_delta_theta = h2e(t1) - h2e(t0)
     vec_delta_theta = vec_delta_theta  / np.linalg.norm(vec_delta_theta, axis=1)[:, None]

--- a/marxs/design/tests/test_design.py
+++ b/marxs/design/tests/test_design.py
@@ -131,6 +131,23 @@ def test_rotated_torus():
     assert np.allclose(rotatedxyz, h2e(mytorus.parametric(theta, phi)))
 
 
+def test_torus_xyzw2parametric():
+    '''Theta, phi coordinates for torus should round-trip to xyz'''
+    R = 2.
+    r = 1.
+
+    angle = np.arange(0, 2 * np.pi, 0.1)
+    phi, theta = np.meshgrid(angle, angle)
+    phi = phi.flatten()
+    theta = theta.flatten()
+    mytorus = RowlandTorus(R=R, r=r)
+
+    xyzw = mytorus.parametric(theta, phi)
+    t, p = mytorus.xyzw2parametric(xyzw)
+    assert np.allclose(np.mod(theta, 2. * np.pi), np.mod(t, 2. * np.pi))
+    assert np.allclose(np.mod(phi, 2. * np.pi), np.mod(p, 2. * np.pi))
+
+
 def test_torus_normal():
     '''Compare the analytic normal with a numeric result.
 
@@ -147,15 +164,17 @@ def test_torus_normal():
     mytorus = RowlandTorus(R=R, r=r)
 
     xyz = mytorus.parametric(theta, phi)
-    t1 = mytorus.parametric(theta + 0.001, phi)
-    p1 = mytorus.parametric(theta, phi + 0.001)
-    t0 = mytorus.parametric(theta - 0.001, phi)
-    p0 = mytorus.parametric(theta, phi - 0.001)
+    t1 = mytorus.parametric(theta + 0.00001, phi)
+    p1 = mytorus.parametric(theta, phi + 0.00001)
+    t0 = mytorus.parametric(theta - 0.00001, phi)
+    p0 = mytorus.parametric(theta, phi - 0.00001)
 
     vec_normal = mytorus.normal(h2e(xyz))
 
     vec_delta_theta = h2e(t1) - h2e(t0)
+    vec_delta_theta = vec_delta_theta  / np.linalg.norm(vec_delta_theta, axis=1)[:, None]
     vec_delta_phi = h2e(p1) - h2e(p0)
+    vec_delta_phi = vec_delta_phi  / np.linalg.norm(vec_delta_phi, axis=1)[:, None]
 
     assert np.allclose(np.sqrt(np.sum(vec_normal * vec_normal, axis=1)), 1.)
     assert np.allclose(np.einsum('ij,ij->i', vec_normal, vec_delta_theta), 0.)
@@ -398,7 +417,8 @@ def test_nojumpsinCCDorientation():
     rowland = RowlandTorus(R, r, pos4d=pos4d)
     det = RowlandCircleArray(rowland=rowland,
                              elem_class=mock_facet,
-                             d_element=49.652, theta=[np.pi - 0.2, np.pi + 0.5])
+                             d_element=49.652, #theta=[np.pi - 0.2, np.pi + 0.5])
+                             theta=[np.pi - 0.2, np.pi - 0.1])
 
     # If all is right, this will vary very smoothly along the circle.
     xcomponent = np.array([e.geometry['e_y'][0] for e in det.elements])

--- a/marxs/simulator/simulator.py
+++ b/marxs/simulator/simulator.py
@@ -3,7 +3,7 @@ from transforms3d.affines import decompose44
 
 from ..math.utils import translation2aff, zoom2aff, mat2aff
 from ..base import SimulationSequenceElement, _parse_position_keywords
-from ..math.pluecker import h2e
+from ..math.pluecker import h2e, e2h
 import transforms3d
 from transforms3d.utils import normalized_vector
 
@@ -331,6 +331,8 @@ class ParallelCalculated(Parallel):
         xyzw = self.get_elemxyzw()
         normals = self.get_spec('normal_spec', xyzw)
         parallels = self.get_spec('parallel_spec', xyzw, normals)
+        normals = h2e(normals)
+        parallels = h2e(parallels)
 
         for i in range(xyzw.shape[0]):
             rot_mat = np.zeros((3,3))
@@ -354,10 +356,10 @@ class ParallelCalculated(Parallel):
         elif len(spec) == 4:
             # vector in homogeneous coordinates
             if spec[3] == 0:
-                return np.tile(spec[:3], (xyzw.shape[0], 1))
+                return np.tile(spec, (xyzw.shape[0], 1))
             # position in homogeneous coordinates
             else:
-                return h2e(xyzw) - h2e(spec)[None, :]
+                return e2h(h2e(xyzw) - h2e(spec)[None, :], 1)
         else:
             raise ValueError(specname + 'must be callable of homogeneous coordinate.')
 


### PR DESCRIPTION
It turns out that the existing code did not construct normal to the Rowland Torus in a consistent way. Sometimes, the normal would point inwards and sometimes outward. The entire rowland.normal code has been re-designed to use parametric representation or the torus wherever possible.