### PR TITLE
fix bug in RectangularGrid

### DIFF
--- a/marxs/design/__init__.py
+++ b/marxs/design/__init__.py
@@ -1,4 +1,5 @@
 from .rowland import (RowlandTorus,
                       GratingArrayStructure, LinearCCDArray,
+                      RectangularGrid,
                       RowlandCircleArray,
                       find_radius_of_photon_shell)

--- a/marxs/design/rowland.py
+++ b/marxs/design/rowland.py
@@ -846,7 +846,7 @@ class RectangularGrid(ParallelCalculated, OpticalElement):
 
             # Find the rotation between [1, 0, 0] and the new normal
             # Keep grooves (along e_y) parallel to e_y
-            rot_mat = ex2vec_fix(normals[i, :], parallels[i, :])
+            rot_mat = ex2vec_fix(h2e(normals[i, :]), h2e(parallels[i, :]))
 
             pos4d.append(transforms3d.affines.compose(h2e(xyzw[i, :]), rot_mat, np.ones(3)))
         return pos4d

--- a/marxs/optics/tests/test_interfacecomplience.py
+++ b/marxs/optics/tests/test_interfacecomplience.py
@@ -12,7 +12,8 @@ from ..aperture import BaseAperture
 from ...source import PointSource, FixedPointing
 from ..base import _parse_position_keywords, FlatStack
 from ...design import (RowlandTorus, GratingArrayStructure,
-                       LinearCCDArray, RowlandCircleArray)
+                       LinearCCDArray, RowlandCircleArray,
+                       RectangularGrid)
 from ..baffle import Baffle
 from ..multiLayerMirror import MultiLayerMirror
 from ...simulator import Sequence
@@ -47,6 +48,12 @@ all_oe = [ThinLens(focallength=100),
                              elem_args={'zoom': 0.04, 'd': 1e-3,
                                         'order_selector': constant_order_factory(1)},
                              d_element=0.1,theta=[np.pi - 0.2, np.pi + 0.1]),
+          RectangularGrid(rowland=mytorus, elem_class=FlatGrating,
+                          elem_args={'zoom': 0.04, 'd': 1e-3,
+                                     'order_selector': constant_order_factory(1)},
+                          d_element=0.1, x_range=[0.8, 1.1], y_range=[0, 0.1],
+                          z_range=[0, 0.1]),
+
           Baffle(),
           MultiLayerMirror('./marxs/optics/data/testFile_mirror.txt', './marxs/optics/data/ALSpolarization2.txt'),
           Sequence(elements=[]),


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "run_eqpeg_long.py", line 7, in <module>
    import arcus
  File "/melkor/d1/guenther/projects/ARCUS/arcus/arcus.py", line 146, in <module>
    y_range=[-180, 180], **gratinggrid)
  File "/nfs/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/marxs-0.1.dev400-py2.7.egg/marxs/design/rowland.py", line 808, in __init__
    super(RectangularGrid, self).__init__(**kwargs)
  File "/nfs/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/marxs-0.1.dev400-py2.7.egg/marxs/simulator/simulator.py", line 311, in __init__
    kwargs['elem_pos'] = self.calculate_elempos()
  File "/nfs/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/marxs-0.1.dev400-py2.7.egg/marxs/design/rowland.py", line 849, in calculate_elempos
    rot_mat = ex2vec_fix(normals[i, :], parallels[i, :])
  File "/nfs/melkor/d1/guenther/soft/anaconda/lib/python2.7/site-packages/marxs-0.1.dev400-py2.7.egg/marxs/math/rotations.py", line 40, in ex2vec_fix
    rot[:, 0] = e1
ValueError: could not broadcast input array from shape (4) into shape (3)
```