### PR TITLE
Allow change of geometry after init

### DIFF
--- a/marxs/analysis/coords.py
+++ b/marxs/analysis/coords.py
@@ -35,7 +35,7 @@ class ProjectOntoPlane(FlatOpticalElement):
     '''name for output columns of the projected position in plane coordinates.'''
 
     def process_photons(self, photons):
-        vec_center_inter = - h2e(self.geometry['center']) + h2e(photons['pos'])
-        photons[self.loc_coos_name[0]] = np.dot(vec_center_inter, h2e(self.geometry['e_y']))
-        photons[self.loc_coos_name[1]] = np.dot(vec_center_inter, h2e(self.geometry['e_z']))
+        vec_center_inter = - h2e(self.geometry('center')) + h2e(photons['pos'])
+        photons[self.loc_coos_name[0]] = np.dot(vec_center_inter, h2e(self.geometry('e_y')))
+        photons[self.loc_coos_name[1]] = np.dot(vec_center_inter, h2e(self.geometry('e_z')))
         return photons

--- a/marxs/design/tests/test_design.py
+++ b/marxs/design/tests/test_design.py
@@ -278,7 +278,7 @@ def test_facet_rotation_via_facetargs():
     mygas = GratingArrayStructure(mytorus, d_element=60., x_range=[5e3,1e4], radius=[538., 550.], elem_class=FlatGrating, elem_args={'zoom': 30, 'd':0.0002, 'order_selector': gratingeff})
     blaze = transforms3d.axangles.axangle2mat(np.array([0,1,0]), np.deg2rad(15.))
     mygascat = GratingArrayStructure(mytorus, d_element=60., x_range=[5e3,1e4], radius=[538., 550.], elem_class=FlatGrating, elem_args={'zoom': 30, 'orientation': blaze, 'd':0.0002, 'order_selector': gratingeff})
-    assert np.allclose(np.rad2deg(np.arccos(np.dot(mygas.elements[0].geometry['e_x'][:3], mygascat.elements[0].geometry['e_x'][:3]))), 15.)
+    assert np.allclose(np.rad2deg(np.arccos(np.dot(mygas.elements[0].geometry('e_x')[:3], mygascat.elements[0].geometry('e_x')[:3]))), 15.)
 
 def test_persistent_facetargs():
     '''Make sure that facet_args is still intact after generating facets.
@@ -348,11 +348,11 @@ def test_LinearCCDArray():
     assert len(ccds.elements) == 7
     for e in ccds.elements:
         # For this test we don't care if z and e_z are parallel or antiparallel
-        assert np.isclose(np.abs(np.dot([0, 0, 1, 0], e.geometry['e_z'])), 1.)
+        assert np.isclose(np.abs(np.dot([0, 0, 1, 0], e.geometry('e_z'))), 1.)
         assert (e.pos4d[0, 3] >= 0) and (e.pos4d[0, 3] < 1.)
 
     # center ccd is on the optical axis
-    assert np.allclose(ccds.elements[3].geometry['e_y'], [0, 1, 0, 0])
+    assert np.allclose(ccds.elements[3].geometry('e_y'), [0, 1, 0, 0])
 
 def test_LinearCCDArray_rotatated():
     '''Test an array with different rotations.
@@ -368,7 +368,7 @@ def test_LinearCCDArray_rotatated():
                           radius=[-100., 100.], phi=0., elem_class=mock_facet)
     assert len(ccds.elements) == 7
     for e in ccds.elements:
-        assert np.isclose(np.dot([0, -0.8660254, 0.5], e.geometry['e_z'][:3]), 0, atol=1e-4)
+        assert np.isclose(np.dot([0, -0.8660254, 0.5], e.geometry('e_z')[:3]), 0, atol=1e-4)
 
 def test_impossible_LinearCCDArray():
     '''The rotation is chosen such that all requested detector positions are
@@ -421,6 +421,6 @@ def test_nojumpsinCCDorientation():
                              theta=[np.pi - 0.2, np.pi - 0.1])
 
     # If all is right, this will vary very smoothly along the circle.
-    xcomponent = np.array([e.geometry['e_y'][0] for e in det.elements])
+    xcomponent = np.array([e.geometry('e_y')[0] for e in det.elements])
     xcompdiff = np.diff(xcomponent)
     assert (np.max(np.abs(xcompdiff)) / np.median(np.abs(xcompdiff))) < 1.1

--- a/marxs/missions/chandra/hess.py
+++ b/marxs/missions/chandra/hess.py
@@ -72,5 +72,5 @@ class HETG(Parallel):
         for i in range(len(self.elements)):
             # No need to calculate those from groove angle
             # They are already in the input table.
-            self.elements[i].geometry['e_groove'][:3] = ul[:, i]
-            self.elements[i].geometry['e_perp_groove'][:3] = ud[:, i]
+            self.elements[i].geometry('e_groove')[:3] = ul[:, i]
+            self.elements[i].geometry('e_perp_groove')[:3] = ud[:, i]

--- a/marxs/optics/aperture.py
+++ b/marxs/optics/aperture.py
@@ -61,7 +61,7 @@ class FlatAperture(BaseAperture, FlatOpticalElement):
         if self.loc_coos_name is not None:
             photons[self.loc_coos_name[0]] = x
             photons[self.loc_coos_name[1]] = y
-        photons['pos'] = self.geometry['center'] + x.reshape((-1, 1)) * self.geometry['v_y'] + y.reshape((-1, 1)) * self.geometry['v_z']
+        photons['pos'] = self.geometry('center') + x.reshape((-1, 1)) * self.geometry('v_y') + y.reshape((-1, 1)) * self.geometry('v_z')
 
         return photons
 
@@ -84,10 +84,10 @@ class FlatAperture(BaseAperture, FlatOpticalElement):
         '''
         r_out = self.display.get('outer_factor', 3)
         g = self.geometry
-        outer = h2e(g['center']) + r_out * np.vstack([h2e( g['v_y']) + h2e(g['v_z']),
-                                                      h2e(-g['v_y']) + h2e(g['v_z']),
-                                                      h2e(-g['v_y']) - h2e(g['v_z']),
-                                                      h2e( g['v_y']) - h2e(g['v_z'])
+        outer = h2e(g('center')) + r_out * np.vstack([h2e( g('v_y')) + h2e(g('v_z')),
+                                                      h2e(-g('v_y')) + h2e(g('v_z')),
+                                                      h2e(-g('v_y')) - h2e(g('v_z')),
+                                                      h2e( g('v_y')) - h2e(g('v_z'))
         ])
         inner = self.inner_shape()
         return plane_with_hole(outer, inner)
@@ -168,14 +168,14 @@ class RectangleAperture(FlatAperture):
     @property
     def area(self):
         '''Area covered by the aperture'''
-        return 4 * np.linalg.norm(self.geometry['v_y']) * np.linalg.norm(self.geometry['v_z'])
+        return 4 * np.linalg.norm(self.geometry('v_y')) * np.linalg.norm(self.geometry('v_z'))
 
     def inner_shape(self):
         g = self.geometry
-        return h2e(g['center']) + np.vstack([h2e( g['v_y']) + h2e(g['v_z']),
-                                             h2e(-g['v_y']) + h2e(g['v_z']),
-                                             h2e(-g['v_y']) - h2e(g['v_z']),
-                                             h2e( g['v_y']) - h2e(g['v_z'])])
+        return h2e(g('center')) + np.vstack([h2e( g('v_y')) + h2e(g('v_z')),
+                                             h2e(-g('v_y')) + h2e(g('v_z')),
+                                             h2e(-g('v_y')) - h2e(g('v_z')),
+                                             h2e( g('v_y')) - h2e(g('v_z'))])
 
 
 class CircleAperture(FlatAperture):
@@ -205,8 +205,8 @@ class CircleAperture(FlatAperture):
     def generate_local_xy(self, n):
         phi = np.random.uniform(self.phi[0], self.phi[1], n)
         r = np.sqrt(np.random.random(n))
-        if not np.isclose(np.linalg.norm(self.geometry['v_y']),
-                        np.linalg.norm(self.geometry['v_z'])):
+        if not np.isclose(np.linalg.norm(self.geometry('v_y')),
+                          np.linalg.norm(self.geometry('v_z'))):
             raise GeometryError('Aperture does not have same size in y, z direction.')
 
         x = r * np.cos(phi)
@@ -216,13 +216,13 @@ class CircleAperture(FlatAperture):
     @property
     def area(self):
         '''Area covered by the aperture'''
-        return 2. * np.pi * np.linalg.norm(self.geometry['v_y'])
+        return 2. * np.pi * np.linalg.norm(self.geometry('v_y'))
 
     def inner_shape(self):
         n = self.display.get('n_inner_vertices', 90)
         phi = np.linspace(0.5 * np.pi, 2.5 * np.pi, n, endpoint=False)
-        v_y = self.geometry['v_y']
-        v_z = self.geometry['v_z']
+        v_y = self.geometry('v_y')
+        v_z = self.geometry('v_z')
 
         x = np.cos(phi)
         y = np.sin(phi)
@@ -234,7 +234,7 @@ class CircleAperture(FlatAperture):
         x[~ind] = 0
         y[~ind] = 0
 
-        return h2e(self.geometry['center'] + x.reshape((-1, 1)) * v_y + y.reshape((-1, 1)) * v_z)
+        return h2e(self.geometry('center') + x.reshape((-1, 1)) * v_y + y.reshape((-1, 1)) * v_z)
 
 
 class MultiAperture(BaseAperture, BaseContainer):

--- a/marxs/optics/mirror.py
+++ b/marxs/optics/mirror.py
@@ -3,7 +3,7 @@ import numpy as np
 from transforms3d.axangles import axangle2mat
 
 from .base import FlatOpticalElement
-from ..math.pluecker import *
+from ..math.pluecker import h2e, e2h, distance_point_point
 from ..math.utils import norm_vector
 
 class PerfectLens(FlatOpticalElement):
@@ -28,7 +28,7 @@ class PerfectLens(FlatOpticalElement):
     def process_photons(self, photons):
         # A ray through the center is not broken.
         # So, find out where a central ray would go.
-        focuspoints = h2e(self.geometry['center']) + self.focallength * norm_vector(h2e(photons['dir']))
+        focuspoints = h2e(self.geometry('center')) + self.focallength * norm_vector(h2e(photons['dir']))
         photons['dir'] = e2h(focuspoints - h2e(photons['pos']), 0)
         return photons
 
@@ -78,7 +78,7 @@ class ThinLens(FlatOpticalElement):
     def process_photon(self, dir, pos, energy, polerization):
         intersect, h_intersect, loc_inter = self.intersect(dir, pos)
         distance = distance_point_point(h_intersect,
-                                        self.geometry['center'][np.newaxis, :])
+                                        self.geometry('center')[np.newaxis, :])
         if distance == 0.:
             # No change of direction for rays through the origin.
             # Need to special case this, because rotation axis is not defined
@@ -86,7 +86,7 @@ class ThinLens(FlatOpticalElement):
             new_ray_dir = h2e(dir)
         else:
             delta_angle = distance / self.focallength
-            e_rotation_axis = np.cross(dir[:3], (h_intersect - self.geometry['center'])[:3])
+            e_rotation_axis = np.cross(dir[:3], (h_intersect - self.geometry('center'))[:3])
             # This is the first step that cannot be done on a stack of photons
             # Could have a for "i in photons", but might come up with better way
             rot = axangle2mat(e_rotation_axis, delta_angle)

--- a/marxs/optics/multiLayerMirror.py
+++ b/marxs/optics/multiLayerMirror.py
@@ -73,7 +73,7 @@ class MultiLayerMirror(FlatOpticalElement):
 
         # split polarization into s and p components
         # v_1 is s polarization (perpendicular to plane of incidence), v_2 is p polarization (in the plane of incidence)
-        v_1 = np.cross(beam_dir, self.geometry['e_x'][0:3])
+        v_1 = np.cross(beam_dir, self.geometry('e_x')[0:3])
         v_1 /= np.linalg.norm(v_1, axis=1)[:, np.newaxis]
         v_2 = np.cross(beam_dir, v_1)
         # find polarization component in each direction, v1 and v2
@@ -102,7 +102,7 @@ class MultiLayerMirror(FlatOpticalElement):
         # find probability of being reflected due to position
         # put the photon positions and the position values from the reflection file into local coordinates
         local_intersection = h2e((np.dot(pos4d_inv, intersection.T)).T)
-        local_coords_in_file = reflectFile['X(mm)'] / np.linalg.norm(self.geometry['v_y']) - 1
+        local_coords_in_file = reflectFile['X(mm)'] / np.linalg.norm(self.geometry('v_y')) - 1
         # interpolate 'Peak lambda', 'Peak' [reflectivity], and 'FWHM(nm)' to the actual photon positions
         peak_wavelength = np.interp(local_intersection[:,1], local_coords_in_file, reflectFile['Peak lambda'])
         max_refl = np.interp(local_intersection[:,1], local_coords_in_file, reflectFile['Peak']) / tested_polarized_fraction

--- a/marxs/optics/tests/test_optics.py
+++ b/marxs/optics/tests/test_optics.py
@@ -32,18 +32,18 @@ def test_pos4d_no_transformation():
     '''
     oe = marxs.optics.aperture.RectangleAperture()
     assert np.all(oe.pos4d == np.eye(4))
-    assert np.all(oe.geometry['center'] == np.array([0, 0, 0, 1]))
-    assert np.all(oe.geometry['e_y'] == np.array([0, 1, 0, 0]))
-    assert np.all(oe.geometry['e_z'] == np.array([0, 0, 1, 0]))
+    assert np.all(oe.geometry('center') == np.array([0, 0, 0, 1]))
+    assert np.all(oe.geometry('e_y') == np.array([0, 1, 0, 0]))
+    assert np.all(oe.geometry('e_z') == np.array([0, 0, 1, 0]))
 
 
 def test_pos4d_rotation():
     rotation = axangle2aff(np.array([1, 1, 0]), np.deg2rad(90))
     oe = marxs.optics.aperture.RectangleAperture(orientation=rotation[:3,:3])
     assert np.all(oe.pos4d == rotation)
-    assert np.all(oe.geometry['center'] == np.array([0, 0, 0, 1]))
-    assert np.allclose(oe.geometry['e_y'], np.array([.5, .5, 1. / np.sqrt(2), 0]))
-    assert np.allclose(oe.geometry['e_z'], np.array([1., -1, 0, 0]) / np.sqrt(2))
+    assert np.all(oe.geometry('center') == np.array([0, 0, 0, 1]))
+    assert np.allclose(oe.geometry('e_y'), np.array([.5, .5, 1. / np.sqrt(2), 0]))
+    assert np.allclose(oe.geometry('e_z'), np.array([1., -1, 0, 0]) / np.sqrt(2))
 
 
 def test_pos4d_translation():
@@ -51,9 +51,9 @@ def test_pos4d_translation():
     expectedpos4d = np.eye(4)
     expectedpos4d[:3, 3] = np.array([-2, 3, 4.3])
     assert np.all(oe.pos4d == expectedpos4d)
-    assert np.all(oe.geometry['center'] == np.array([-2, 3, 4.3, 1]))
-    assert np.all(oe.geometry['e_y'] == np.array([0, 1, 0, 0]))
-    assert np.all(oe.geometry['e_z'] == np.array([0, 0, 1, 0]))
+    assert np.all(oe.geometry('center') == np.array([-2, 3, 4.3, 1]))
+    assert np.all(oe.geometry('e_y') == np.array([0, 1, 0, 0]))
+    assert np.all(oe.geometry('e_z') == np.array([0, 0, 1, 0]))
 
 
 
@@ -121,9 +121,9 @@ def test_FlatStack():
                                 elements=[marxs.optics.EnergyFilter, marxs.optics.FlatDetector],
                                 keywords=[{'filterfunc': lambda x: 0.5},{}])
     # Check all layers are at the same position
-    assert np.allclose(fs.geometry['center'], np.array([0, 5, 0, 1]))
-    assert np.allclose(fs.elements[0].geometry['center'], np.array([0, 5, 0, 1]))
-    assert np.allclose(fs.elements[1].geometry['center'], np.array([0, 5, 0, 1]))
+    assert np.allclose(fs.geometry('center'), np.array([0, 5, 0, 1]))
+    assert np.allclose(fs.elements[0].geometry('center'), np.array([0, 5, 0, 1]))
+    assert np.allclose(fs.elements[1].geometry('center'), np.array([0, 5, 0, 1]))
     assert np.allclose(fs.pos4d, fs.elements[1].pos4d)
 
     p = generate_test_photons(5)

--- a/marxs/tests/test_simulator.py
+++ b/marxs/tests/test_simulator.py
@@ -65,7 +65,7 @@ def test_list_elemargs():
     for p in [p0, p1, p2]:
         assert len(p.elements) == 2
         for e in p.elements:
-            assert np.linalg.norm(e.geometry['v_y']) == 3
+            assert np.linalg.norm(e.geometry('v_y')) == 3
         assert p.elements[0]._d == 0.001
         assert p.elements[1]._d == 0.002
 


### PR DESCRIPTION
In MARXS 0.1 the geometry could not be changed after init
because a lot of stuff was pre-calculated in __init__. That should no
longer be the case.

self.geometry is now a function that dynamically calcultes vectors from
self.pos4d, so that the same information is not dublicated.

closes #96