### PR TITLE
fix bug: PerfectLens would not update pos

### DIFF
--- a/marxs/math/pluecker.py
+++ b/marxs/math/pluecker.py
@@ -134,8 +134,9 @@ def intersect_line_plane(p_line, h_plane):
 
 def point_dir2plane(h_point, h_dir):
     h_plane = np.empty(4)
-    h_plane[:3] = h_dir[:3]
-    h_plane[3] = - np.dot(h_point, h_dir) / h_point[3]
+    h_dir_n = h_dir / np.linalg.norm(h_dir)
+    h_plane[:3] = h_dir_n[:3]
+    h_plane[3] = - np.dot(h_point, h_dir_n) / h_point[3]
     return h_plane
 
 #   @ L = {U:UxQ}, for U the direction of L and Q a point on L.

--- a/marxs/optics/mirror.py
+++ b/marxs/optics/mirror.py
@@ -21,16 +21,17 @@ class PerfectLens(FlatOpticalElement):
                'opacity': 0.5,
     }
 
+    loc_coos_name = ['mirror_x', 'mirror_y']
+
     def __init__(self, **kwargs):
         self.focallength = kwargs.pop('focallength')
         super(PerfectLens, self).__init__(**kwargs)
 
-    def process_photons(self, photons):
+    def specific_process_photons(self, photons, intersect, interpos, intercoos):
         # A ray through the center is not broken.
         # So, find out where a central ray would go.
-        focuspoints = h2e(self.geometry('center')) + self.focallength * norm_vector(h2e(photons['dir']))
-        photons['dir'] = e2h(focuspoints - h2e(photons['pos']), 0)
-        return photons
+        focuspoints = h2e(self.geometry('center')) + self.focallength * norm_vector(h2e(photons['dir'][intersect]))
+        return {'dir': e2h(focuspoints - h2e(interpos[intersect]), 0)}
 
 class ThinLens(FlatOpticalElement):
     '''Focus rays with the thin lens approximation

--- a/marxs/optics/tests/test_mirror.py
+++ b/marxs/optics/tests/test_mirror.py
@@ -2,21 +2,24 @@ import numpy as np
 import pytest
 from astropy.coordinates import SkyCoord
 from ... import source, optics
+from ...math.pluecker import h2e
 
 
 @pytest.mark.parametrize("ra", [0., 30., -60.])
 def test_PerfectLens(ra):
     mysource = source.PointSource(coords=SkyCoord(0., ra, unit="deg"))
     mypointing = source.FixedPointing(coords=SkyCoord(0., 0., unit='deg'))
-    myslit = optics.RectangleAperture(zoom=2)
+    myslit = optics.RectangleAperture(zoom=2, position=[+100, 0, 0])
     f = 1000
-    lens = optics.PerfectLens(focallength=f, zoom=40)
+    lens = optics.PerfectLens(focallength=f, zoom=400)
 
     photons = mysource.generate_photons(11)
     photons = mypointing.process_photons(photons)
     photons = myslit.process_photons(photons)
+    assert np.allclose(h2e(photons['pos'].data)[:, 0], 100.)
 
     photons = lens.process_photons(photons)
+    assert np.allclose(h2e(photons['pos'].data)[:, 0], 0.)
 
     # How far away do I need to put a detector to hit the focal point?
     d = f * np.cos(np.deg2rad(ra))

--- a/marxs/tests/test_analysis.py
+++ b/marxs/tests/test_analysis.py
@@ -36,7 +36,7 @@ def test_resolvingpower_consistency():
     '''
     entrance = np.array([12000., 0., 0.])
     aper = CircleAperture(position=entrance, zoom=100)
-    lens = PerfectLens(focallength=12000., position=entrance)
+    lens = PerfectLens(focallength=12000., position=entrance, zoom=100)
     rms = RadialMirrorScatter(inplanescatter=1e-4,
                               perpplanescatter=1e-5,
                               position=entrance)


### PR DESCRIPTION
Relatedly, the mirror would be so tiny that it's essentially invisible in plotting. Not mirrors need ot have a size and work more like any other flat element. This also allows the user to have two different lenses of the Perfectlens class in the same simulations. (Before this, they would have a global effect on all photons.)