### PR TITLE
try abs path for _static because it is not found on RTD

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,7 +131,7 @@ rst_epilog += '''
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = [os.path.abspath(os.path.join(os.path.dirname(__file__), '_static'))]
 
 
 # Output file base name for HTML help builder.


### PR DESCRIPTION
Unfortunately, I cannot run this on readthedocs just for tryout easily, so I'll merge this and see if it works. It;s not a big change in any case.