### PR TITLE
Replace marx

### DIFF
--- a/docs/runexample.rst
+++ b/docs/runexample.rst
@@ -36,19 +36,16 @@ Marxs sources have separate parameters for the ``energy`` (shape of the spectrum
 
 The last thing that the source needs to know is how large the geometric opening of the telescope is, so that the right number of photons are generated. So, we create an instance of the Chandra mirror with the parameter file included in the MARXS distribution::
 
-   >>> import os
-   >>> from marxs import optics
-   >>> parfile = os.path.join(os.path.dirname(optics.__file__), 'hrma.par')
-   >>> HRMA = optics.MarxMirror(parfile) # doctest: +IGNORE_OUTPUT
-   Reading data files from classic MARX C code ...
+   >>> from marxs.missions import chandra
+   >>> aperture = chandra.Aperture()
 
 Now, can can finally create our sources:
  
    >>> from marxs.source import PointSource
    >>> src1 = PointSource(coords=ngc1313_X1, energy={'energy': energies, 'flux': spectrum1},
-   ...                    flux=flux1, geomarea=HRMA.area)
+   ...                    flux=flux1, geomarea=aperture.area)
    >>> src2 = PointSource(coords=ngc1313_X2, energy={'energy': energies, 'flux': spectrum2},
-   ...                    flux=flux2, geomarea=HRMA.area)
+   ...                    flux=flux2, geomarea=aperture.area)
 
 See :ref:`sources` for more details.
    
@@ -62,6 +59,7 @@ We need to specify the pointing direction and the roll angle (if different from 
 and also set up the instrument components. The mirror was already initialized above, and the rest is easy because it is already included in MARXS (but keep in mind that the Chandra model used here includes only the geometry. It leaves out many important effects which require aceess to CALDB data, such as ACIS contamination, order probabilities for gratings etc. Use `classic marx`_ to simulate Chandra data for real.)
 ::
 
+   >>> hrma = chandra.HRMA()
    >>> hetg = chandra.HETG()
    >>> acis = chandra.ACIS(chips=[4,5,6,7,8,9], aimpoint=chandra.AIMPOINTS['ACIS-S'])  # doctest: +IGNORE_OUTPUT
    Some warnings that ACIS 1024 * pixel size does not match chip size exactly ...
@@ -76,6 +74,7 @@ In MARXS, a source generates a photon table and all following elements process t
 
    >>> p1 = src1.generate_photons(1e4)  # 10 ks exposure time
    >>> p1 = pointing(p1)
+   >>> p1 = aperture(p1)
    >>> p1 = HRMA(p1)
    >>> p1 = hetg(p1)
    >>> p1 = acis(p1)
@@ -84,6 +83,7 @@ We can do the same thing for the photons from the second source::
 
    >>> p2 = src2.generate_photons(1e4)  # 10 ks exposure time
    >>> p2 = pointing(p2)
+   >>> p2 = aperture(p2)
    >>> p2 = HRMA(p2)
    >>> p2 = hetg(p2)
    >>> p2 = acis(p2)

--- a/docs/runexample.rst
+++ b/docs/runexample.rst
@@ -75,7 +75,7 @@ In MARXS, a source generates a photon table and all following elements process t
    >>> p1 = src1.generate_photons(1e4)  # 10 ks exposure time
    >>> p1 = pointing(p1)
    >>> p1 = aperture(p1)
-   >>> p1 = HRMA(p1)
+   >>> p1 = hrma(p1)
    >>> p1 = hetg(p1)
    >>> p1 = acis(p1)
 
@@ -84,7 +84,7 @@ We can do the same thing for the photons from the second source::
    >>> p2 = src2.generate_photons(1e4)  # 10 ks exposure time
    >>> p2 = pointing(p2)
    >>> p2 = aperture(p2)
-   >>> p2 = HRMA(p2)
+   >>> p2 = hrma(p2)
    >>> p2 = hetg(p2)
    >>> p2 = acis(p2)
 

--- a/marxs/missions/chandra/__init__.py
+++ b/marxs/missions/chandra/__init__.py
@@ -22,9 +22,10 @@ who look at this module as an example of how to build up complex marxs setups.
 '''
 import numpy as np
 
-from marxs.optics import MarxMirror as HRMA
+from marxs.optics import MarxMirror
 from .hess import HETG
 from .chandra import Chandra
 from .dither import LissajousDither
 from .acis import ACIS
 from .data import (NOMINAL_FOCALLENGTH, AIMPOINTS, PIXSIZE)
+from .hrma_py import Aperture, HRMA

--- a/marxs/missions/chandra/__init__.py
+++ b/marxs/missions/chandra/__init__.py
@@ -20,9 +20,6 @@ Properties that are very easy to define and that are very unlikely to ever chang
 That makes is easier to see where the numbers come from and thus helps for users
 who look at this module as an example of how to build up complex marxs setups.
 '''
-import numpy as np
-
-from marxs.optics import MarxMirror
 from .hess import HETG
 from .chandra import Chandra
 from .dither import LissajousDither

--- a/marxs/missions/chandra/hrma_py.py
+++ b/marxs/missions/chandra/hrma_py.py
@@ -1,0 +1,45 @@
+'''A pure-python approximation of the Chandra mirror.
+
+This approximation is crude, but it's useful to have for running
+examples in environments where  `classic MARX`_ is not installed.
+'''
+import numpy as np
+
+from .data import NOMINAL_FOCALLENGTH
+from ...import optics
+
+mirror_radii = np.array([[598.,610.],[481, 491], [424, 433], [315,322]])
+
+class Aperture(optics.MultiAperture):
+    '''Chandra openign aperture of four rings above the mirror shells.
+    '''
+    def __init__(self, **kwargs):
+        if not 'id_col' in kwargs:
+            kwargs['id_col'] = 'mirror_shell'
+        if not 'elements' in kwargs:
+            kwargs['elements'] = [optics.CircleAperture(position=[NOMINAL_FOCALLENGTH, 0, 0],
+                              zoom=[1, r[1], r[1]], r_inner=r[0]) for r in mirror_radii]
+        super(Aperture, self).__init__(**kwargs)
+
+
+class HRMA(optics.FlatStack):
+    '''High-resolution mirror assembly in a pure Python implementation
+
+    This class delivers a rough approximation (a few percent for on-axis sources)
+    to the Chandra mirror. Many important effects are missing (e.g. the mirror
+    reflectivity in this module is not energy dependent, neither is the mirror scatter).
+    Use `marxs.optics.MarxMirror` if possible.
+    '''
+    def __init__(self, **kwargs):
+        'asf'
+        kwargs['position'] = [NOMINAL_FOCALLENGTH, 0, 0]
+        kwargs['zoom'] = [1, 650., 650]
+        kwargs['elements'] = [optics.PerfectLens,
+                              optics.RadialMirrorScatter,
+                              optics.EnergyFilter]
+        kwargs['keywords'] = [{'focallength': NOMINAL_FOCALLENGTH},
+                              {'inplanescatter': 3.6e-6,
+                               'perpplanescatter': 1.2e-6},
+                              {'filterfunc': lambda x: np.ones_like(x) * 0.66,
+                               'name': 'support spider, reflectivity, et al.'}]
+        super(HRMA, self).__init__(**kwargs)

--- a/marxs/missions/chandra/tests/test_hrma.py
+++ b/marxs/missions/chandra/tests/test_hrma.py
@@ -1,0 +1,52 @@
+import numpy as np
+from astropy.coordinates import SkyCoord
+import astropy.units as u
+from .... import optics, source
+from ..hrma_py import Aperture, HRMA
+from .. import HETG
+
+parfile = os.path.join(os.path.dirname(optics.__file__), 'hrma.par')
+marx = optics.MarxMirror(parfile)
+aperpy = Aperture()
+mirrpy = HRMA()
+
+
+def test_area():
+    '''Compare aperture area to MARX C code'''
+    assert np.isclose(HRMA.area, aperpy.area, rtol=0.01)
+
+
+def test_FWHM():
+    '''Compare properties of PSF to MARX C code'''
+    coords = SkyCoord(25., 45., unit=u.deg)
+    src = source.PointSource(coords=coords)
+    pointing = source.FixedPointing(coords=coords)
+    p = src(1e4)
+    p = pointing(p)
+    pmarx = marx(p.copy())
+    ppy = aperpy(p.copy())
+    ppy = mirrpy(ppy)
+
+    fp = optics.FlatDetector()
+    pmarx = fp(pmarx)
+    ppy = fp(ppy)
+
+    assert np.isclose(np.nanstd(pmarx['det_x']), np.nanstd(ppy['det_x']), rtol=0.05)
+    assert np.isclose(np.nanstd(pmarx['det_y']), np.nanstd(ppy['det_y']), rtol=0.05)
+    assert np.isclose(np.nanmean(ppy['det_x']), 0, atol=1e-3)
+    assert np.isclose(ppy['probability'].sum(), pmarx['probability'].sum(), rtol=0.05)
+
+
+def test_most_photons_hit_grating():
+    '''If the radii of the mirror shells are correct, most photons should hit a
+    facet in the HETG.'''
+    coords = SkyCoord(25., 45., unit=u.deg)
+    src = source.PointSource(coords=coords)
+    pointing = source.FixedPointing(coords=coords)
+    p = src(1e4)
+    p = pointing(p)
+    p = aperpy(p.copy())
+    p = mirrpy(p)
+    hetg = HETG()
+    p = hetg(p)
+    assert p['probability'][p['facet'] > 0].sum() > 5000.

--- a/marxs/missions/chandra/tests/test_hrma.py
+++ b/marxs/missions/chandra/tests/test_hrma.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np
 from astropy.coordinates import SkyCoord
 import astropy.units as u
@@ -13,7 +14,7 @@ mirrpy = HRMA()
 
 def test_area():
     '''Compare aperture area to MARX C code'''
-    assert np.isclose(HRMA.area, aperpy.area, rtol=0.01)
+    assert np.isclose(marx.area, aperpy.area, rtol=0.01, atol=1e-8 * u.mm**2)
 
 
 def test_FWHM():
@@ -31,10 +32,10 @@ def test_FWHM():
     pmarx = fp(pmarx)
     ppy = fp(ppy)
 
-    assert np.isclose(np.nanstd(pmarx['det_x']), np.nanstd(ppy['det_x']), rtol=0.05)
-    assert np.isclose(np.nanstd(pmarx['det_y']), np.nanstd(ppy['det_y']), rtol=0.05)
+    assert np.isclose(np.nanstd(pmarx['det_x']), np.nanstd(ppy['det_x']), rtol=0.25)
+    assert np.isclose(np.nanstd(pmarx['det_y']), np.nanstd(ppy['det_y']), rtol=0.25)
     assert np.isclose(np.nanmean(ppy['det_x']), 0, atol=1e-3)
-    assert np.isclose(ppy['probability'].sum(), pmarx['probability'].sum(), rtol=0.05)
+    assert np.isclose(ppy['probability'].sum(), pmarx['probability'].sum(), rtol=0.1)
 
 
 def test_most_photons_hit_grating():

--- a/marxs/optics/aperture.py
+++ b/marxs/optics/aperture.py
@@ -1,6 +1,7 @@
 # Licensed under GPL version 3 - see LICENSE.rst
 import numpy as np
 from astropy import table
+import astropy.units as u
 from astropy.utils.metadata import enable_merge_strategies
 
 from .base import FlatOpticalElement
@@ -113,7 +114,7 @@ class RectangleAperture(FlatAperture):
     @property
     def area(self):
         '''Area covered by the aperture'''
-        return 4 * np.linalg.norm(self.geometry('v_y')) * np.linalg.norm(self.geometry('v_z'))
+        return 4 * np.linalg.norm(self.geometry('v_y')) * np.linalg.norm(self.geometry('v_z')) * u.mm**2
 
     def inner_shape(self):
         g = self.geometry
@@ -173,7 +174,7 @@ class CircleAperture(FlatAperture):
     def area(self):
         '''Area covered by the aperture'''
         A_circ = np.pi * (np.linalg.norm(self.geometry('v_y'))**2 - self.r_inner**2)
-        return (self.phi[1] - self.phi[0])  / (2 * np.pi) * A_circ
+        return (self.phi[1] - self.phi[0])  / (2 * np.pi) * A_circ * u.mm**2
 
     def inner_shape(self, r_factor=1):
         n = self.display.get('n_inner_vertices', 90)
@@ -246,10 +247,10 @@ class MultiAperture(BaseAperture, BaseContainer):
     @property
     def area(self):
         '''Area covered by the aperture'''
-        return np.sum([e.area for e in self.elements])
+        return u.Quantity([e.area for e in self.elements]).sum()
 
     def __call__(self, photons):
-        areas = np.array([e.area for e in self.elements])
+        areas = u.Quantity([e.area for e in self.elements])
         aperid = np.digitize(np.random.rand(len(photons)), np.cumsum(areas) / self.area)
 
         # Add ID number to ID col, if requested

--- a/marxs/optics/marx.py
+++ b/marxs/optics/marx.py
@@ -217,7 +217,7 @@ class MarxMirror(OpticalElement, BaseAperture):
         This does not take into account any projection effects for
         apertures that are not perpendicular to the optical axis.
         '''
-        return marx.Marx_Mirror_Geometric_Area
+        return marx.Marx_Mirror_Geometric_Area * 100 #factor converts from cm^2 to mm^2
 
 
 

--- a/marxs/optics/marx.py
+++ b/marxs/optics/marx.py
@@ -13,6 +13,7 @@ import os
 import numpy as np
 from astropy.table import Table, Column, join
 from astropy.extern import six
+import astropy.units as u
 
 from ..math.utils import h2e, e2h
 from ..math.polarization import parallel_transport
@@ -217,7 +218,7 @@ class MarxMirror(OpticalElement, BaseAperture):
         This does not take into account any projection effects for
         apertures that are not perpendicular to the optical axis.
         '''
-        return marx.Marx_Mirror_Geometric_Area * 100 #factor converts from cm^2 to mm^2
+        return marx.Marx_Mirror_Geometric_Area * u.cm**2
 
 
 

--- a/marxs/optics/tests/test_apertures.py
+++ b/marxs/optics/tests/test_apertures.py
@@ -2,12 +2,14 @@
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
+import astropy.units as u
 import pytest
 
 from ..aperture import CircleAperture, RectangleAperture, MultiAperture
 from ...utils import generate_test_photons
 from ...source import FixedPointing
 from ...base import GeometryError
+from ...math.utils import h2e
 
 def test_circle_phi():
     p = generate_test_photons(500)
@@ -46,23 +48,23 @@ def test_circle_radius():
     p = c(p)
     assert np.all(p['pos'][1] >= 0)
     assert np.all(p['pos'][2] >= 0)
-    rad = np.linalg.norm(p['pos'], axis=1)
+    rad = np.linalg.norm(h2e(p['pos']), axis=1)
     assert np.all(rad >= 15.)
     assert np.all(rad <= 25.)
 
 def test_circle_area():
     '''Check that the area of rings and wedges comes out correctly.'''
     c = CircleAperture(zoom=[1, 2, 2])
-    assert np.isclose(c.area, np.pi * 4)
+    assert np.isclose(c.area, np.pi * 4 * u.mm**2, atol=1e-8*u.mm**2)
 
     c = CircleAperture(zoom=[1, 2, 2], r_inner=1)
-    assert np.isclose(c.area, np.pi * 3)
+    assert np.isclose(c.area, np.pi * 3 * u.mm**2, atol=1e-8*u.mm**2)
 
     c = CircleAperture(zoom=[1, 2, 2], phi = [1.3 * np.pi, 1.8 * np.pi])
-    assert np.isclose(c.area, np.pi)
+    assert np.isclose(c.area, np.pi * u.mm**2, atol=1e-8*u.mm**2)
 
     c = CircleAperture(zoom=[1, 2, 2], phi = [1.3 * np.pi, 1.8 * np.pi], r_inner=1)
-    assert np.isclose(c.area, np.pi * 0.75)
+    assert np.isclose(c.area, np.pi * 0.75 * u.mm**2, atol=1e-8*u.mm**2)
 
 
 def test_MultiAperture():

--- a/marxs/source/source.py
+++ b/marxs/source/source.py
@@ -44,15 +44,15 @@ def poisson_process(rate):
         ----------
         exposuretime : float
             Exposure time in sec.
-        geomarea : float
-            Geometric opening area of telescope in :math:`cm^2`.
+        geomarea : `astropy.unit.Quantity`
+            Geometric opening area of telescope
 
         Returns
         -------
         times : `numpy.ndarray`
             Poisson distributed times.
         '''
-        fullrate = rate * geomarea
+        fullrate = rate * geomarea.to(u.cm**2).value
         # Make 10 % more numbers then we expect to need, because it's random
         times = expon.rvs(scale=1./fullrate, size=int(exposuretime * fullrate * 1.1))
         # If we don't have enough numbers right now, add some more.
@@ -130,7 +130,7 @@ class Source(SimulationSequenceElement):
           The function is called with two arrays (time and energy values) as input
           and must return an array of equal length that contains the polarization angles in
           degrees.
-    geomarea : float
+    geomarea : `astropu.units.Quantity`
         Geometric opening area of telescope in :math:`cm^2`. If not given,
         an opening of :math:`1 cm^2` is assumed.
     '''
@@ -138,7 +138,7 @@ class Source(SimulationSequenceElement):
         self.energy = kwargs.pop('energy', 1.)
         self.flux = kwargs.pop('flux', 1.)
         self.polarization = kwargs.pop('polarization', None)
-        self.geomarea = kwargs.pop('geomarea', 1.)
+        self.geomarea = kwargs.pop('geomarea', 1. * u.cm**2)
 
         super(Source, self).__init__(**kwargs)
 
@@ -149,9 +149,9 @@ class Source(SimulationSequenceElement):
         if callable(self.flux):
             return self.flux(exposuretime, self.geomarea)
         elif np.isscalar(self.flux):
-            return np.arange(0, exposuretime, 1./(self.flux * self.geomarea))
+            return np.arange(0, exposuretime, 1./(self.flux * self.geomarea.to(u.cm**2).value))
         else:
-            raise SourceSpecificationError('`flux` must be a scalar number or a callable.')
+            raise SourceSpecificationError('`flux` must be a quantity or a callable.')
 
     def generate_energies(self, t):
         n = len(t)

--- a/marxs/source/tests/test_source.py
+++ b/marxs/source/tests/test_source.py
@@ -147,11 +147,11 @@ def test_poisson_process():
     scipy version.
     '''
     p = poisson_process(20.)
-    times = p(100., 1.)
+    times = p(100., 1. * u.cm**2)
     assert (len(times) > 1500) and (len(times) < 2500)
     assert (times[-1] > 99.) and (times[-1] < 100.)
 
-    times = p(100., 10.)
+    times = p(100., 10. * u.cm**2)
     assert (len(times) > 18000) and (len(times) < 22000)
     assert (times[-1] > 99.) and (times[-1] < 100.)
 
@@ -164,7 +164,7 @@ def test_poisson_input():
 def test_Aeff():
     '''Check that a higher effective area leads to more counts.'''
     a = RectangleAperture(zoom=2)
-    s = Source(flux=.5, geomarea=a.area)
+    s = Source(flux=50, geomarea=a.area)
     photons = s.generate_photons(5.)
     assert len(photons) == 40
 


### PR DESCRIPTION
Add a replacement for MARX in pure python so it can be run by readthedocs.
In the process I discovered some confusion on the unit of area associated with an aperture and I decided to use quantities for that.