### PR TITLE
Plot cylinders in mayavi

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 New Features
 ^^^^^^^^^^^^
+- Add ability to plot cylinders in Mayavi (for support struts) [#147]
 
 API Changes
 ^^^^^^^^^^^
@@ -16,6 +17,8 @@ API Changes
 
 Bug fixes
 ^^^^^^^^^
+- Added missing keywords in display dict for some objects and fixed exception when plotting
+  things that are not objects. Discovered and fixed as part of [#147].
 
 Other changes and additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/marxs/math/pluecker.py
+++ b/marxs/math/pluecker.py
@@ -4,7 +4,7 @@ construction of the Pluecker coordinates from e.g. two points in space or a dire
 a point.
 '''
 import numpy as np
-
+from numpy.linalg import norm
 
 def angle_line_plane(p_line, h_plane):
     '''Compute angle between normal to plane and line
@@ -12,9 +12,13 @@ def angle_line_plane(p_line, h_plane):
     Parameters
     ----------
     p_line : array-like
-        Line(s)
+        Line(s) in Pluecker coordinates
     h_plane : array-like
-        Plane
+        Plane in homogeneous coordinates
+
+    Returns
+    -------
+    angle : array-like
     '''
     l = p_line[:3]
     p = h_plane[:3]
@@ -24,7 +28,20 @@ def angle_line_plane(p_line, h_plane):
 #  @ L = {U:V}, with 3-tuples U and V, with U.V = 0, and with U non-null.
 
 def e_pointpoint2line(e_p1, e_p2):
-    '''p1, p2 are distinct point on line, direction is p1 -> p2'''
+    '''Return a line in Pluecker coordinates connecting two points.
+
+    p1, p2 are distinct point on line, direction is p1 -> p2
+
+    Parameters
+    ----------
+    e_p1, e_p2: array_like
+        Array of Eucledian positions
+
+    Returns
+    -------
+    p_line : array-like
+        Lines in Pluecker coordinates
+    '''
     p_line = np.empty(e_p1.shape[:-1] + (6,) )
     p_line[..., :3] = e_p2 - e_p1
     p_line[..., 3:] = np.cross(e_p2, e_p1)
@@ -32,6 +49,22 @@ def e_pointpoint2line(e_p1, e_p2):
 
 
 def dir_point2line(e_dir, e_pos):
+    '''Return a line in Pluecker coordinates connecting two points.
+
+    p1, p2 are distinct point on line, direction is p1 -> p2
+
+    Parameters
+    ----------
+    e_dir: array_like
+        Array of Euclidean direction vectors
+    e_point : array-like
+        Array of points in eukledian coordinates
+
+    Returns
+    -------
+    p_line : array-like
+        Lines in Pluecker coordinates
+    '''
     p_line = np.empty(e_dir.shape[:-1] + (6,) )
     p_line[..., :3] = e_dir
     p_line[..., 3:] = np.cross(e_dir, e_pos)
@@ -68,11 +101,26 @@ def intersect_line_plane(p_line, h_plane):
 
 
 def point_dir2plane(h_point, h_dir):
+    '''Return a plane in homogeneous coordinates
+
+    Parameters
+    ----------
+    h_point : array-like
+        Point in plane in homogeneous coordinates
+    h_dir: array_like
+        Normal vector of plane in homogeneous coordinates
+
+    Returns
+    -------
+    p_line : array-like
+        Lines in Pluecker coordinates
+    '''
     h_plane = np.empty(4)
-    h_dir_n = h_dir / np.linalg.norm(h_dir)
+    h_dir_n = h_dir / norm(h_dir)
     h_plane[:3] = h_dir_n[:3]
     h_plane[3] = - np.dot(h_point, h_dir_n) / h_point[3]
     return h_plane
+
 
 #   @ L = {U:UxQ}, for U the direction of L and Q a point on L.
 #   @ L = {qP-pQ:PxQ}, for (P:p) and (Q:q) distinct homogeneous points on L.

--- a/marxs/math/pluecker.py
+++ b/marxs/math/pluecker.py
@@ -4,7 +4,6 @@ construction of the Pluecker coordinates from e.g. two points in space or a dire
 a point.
 '''
 import numpy as np
-from numpy.linalg import norm
 
 def angle_line_plane(p_line, h_plane):
     '''Compute angle between normal to plane and line
@@ -116,7 +115,7 @@ def point_dir2plane(h_point, h_dir):
         Lines in Pluecker coordinates
     '''
     h_plane = np.empty(4)
-    h_dir_n = h_dir / norm(h_dir)
+    h_dir_n = h_dir / np.linalg.norm(h_dir)
     h_plane[:3] = h_dir_n[:3]
     h_plane[3] = - np.dot(h_point, h_dir_n) / h_point[3]
     return h_plane

--- a/marxs/missions/chandra/hrma_py.py
+++ b/marxs/missions/chandra/hrma_py.py
@@ -11,7 +11,7 @@ from ...import optics
 mirror_radii = np.array([[598.,610.],[481, 491], [424, 433], [315,322]])
 
 class Aperture(optics.MultiAperture):
-    '''Chandra openign aperture of four rings above the mirror shells.
+    '''Chandra opening aperture of four rings above the mirror shells.
     '''
     def __init__(self, **kwargs):
         if not 'id_col' in kwargs:

--- a/marxs/optics/base.py
+++ b/marxs/optics/base.py
@@ -15,13 +15,17 @@ class OpticalElement(SimulationSequenceElement):
     This class cannot be used to instanciate an optical element directly, rather it serves as a
     base class from with other optical elements will be derived.
 
-    At the very minumum, any derived class needs to implement either `process_photon` or
-    `process_photons`. If the interaction with the photons (e.g. scattering of a mirror surface)
-    can be implemented in a vectorized way using numpy array operations, the derived class should
-    overwrite `process_photons` (`process_photon` is not used in this case).
-    If no vectorized implementation is available, it is sufficient to overwrite `process_photon`.
-    Marxs will call `process_photons`, which (if not overwritten) contains a simple for-loop to
-    loop over all photons in the array and call `process_photon` on each of them.
+    At the very minumum, any derived class needs to implement `__call__` which
+    typically calls `intersect` and either `process_photon` or
+    `process_photons`. If the interaction with the photons (e.g. scattering of
+    a mirror surface) can be implemented in a vectorized way using numpy array
+    operations, the derived class should overwrite `process_photons`
+    (`process_photon` is not used in this case).  If no vectorized
+    implementation is available, it is sufficient to overwrite
+    `process_photon`.  Marxs will call `process_photons`, which (if not
+    overwritten) contains a simple for-loop to loop over all photons in the
+    array and call `process_photon` on each of them.
+
     '''
 
     def geometry(self, key):
@@ -148,8 +152,8 @@ class OpticalElement(SimulationSequenceElement):
         return dir, pos, energy, polarization, probability, any, other, output, columns
 
     def __call__(self, photons):
-        intersect, interpos, intercoos = self.intersect(photons['dir'].data, photons['pos'].data)
-        return self.process_photons(photons, intersect, interpos, intercoos)
+        intersect_out = self.intersect(photons['dir'].data, photons['pos'].data)
+        return self.process_photons(photons, *intersect_out)
 
     def process_photons(self, photons, intersect, interpos, intercoos):
         '''Simulate interaction of optical element with photons - vectorized.

--- a/marxs/optics/mirror.py
+++ b/marxs/optics/mirror.py
@@ -20,6 +20,7 @@ class PerfectLens(FlatOpticalElement):
 
     display = {'color': (0., 0.5, 0.),
                'opacity': 0.5,
+               'shape': 'box'
     }
 
     loc_coos_name = ['mirror_x', 'mirror_y']

--- a/marxs/visualization/mayavi.py
+++ b/marxs/visualization/mayavi.py
@@ -20,7 +20,7 @@ from . import utils
 # The following import fails on headless servers (Travis, readthedocs).
 # from mayavi import mlab
 # Thus, I've moved the import statement into the individual functions, so that
-# this module can still be imported when Travis or readthedocs to build the documentation.
+# this module can still be imported when Travis or readthedocs build the documentation.
 
 doc_plot='''
     {__doc__}
@@ -93,6 +93,18 @@ def box(obj, display, viewer=None):
     b = mlab.triangular_mesh(corners[:,0], corners[:,1], corners[:,2], triangles,
                         color=display['color'])
     return b
+
+@format_doc(doc_plot)
+def cylinder(obj, display, viewer=None):
+    '''Plot a rectangular box for an object.'''
+    from mayavi import mlab
+
+    x0 = obj.geometry('center') - obj.geometry('v_x')
+    x1 = obj.geometry('center') + obj.geometry('v_x')
+    c = mlab.plot3d([x0[0], x1[0]], [x0[1], x1[1]], [x0[2], x1[2]], color=display['color'],
+                    tube_radius=np.linalg.norm(obj.geometry('v_y')),
+                    tube_sides=display.get('tube_sides', 20))
+    return c
 
 def plot_rays(data, scalar=None, viewer=None,
               kwargssurface={'colormap': 'Accent', 'line_width': 1, 'opacity': .4}):
@@ -169,6 +181,7 @@ plot_registry = {'triangulation': triangulation,
                  'surface': surface,
                  'box': box,
                  'container': container,
+                 'cylinder': cylinder,
                  }
 
 

--- a/marxs/visualization/tests/test_utils.py
+++ b/marxs/visualization/tests/test_utils.py
@@ -2,7 +2,9 @@
 import numpy as np
 import pytest
 
-from ..utils import plane_with_hole, get_color, color_tuple_to_hex, format_saved_positions
+from ..utils import (plane_with_hole, get_color, color_tuple_to_hex,
+                     format_saved_positions, MARXSVisualizationWarning)
+from ..mayavi import plot_object
 
 def test_hole_round():
     '''Ensure that plane around the inner hole closes properly at the last point.'''
@@ -84,3 +86,60 @@ def test_empty_format_saved_positions():
         d = format_saved_positions(a)
 
     assert 'contains no data' in str(e.value)
+
+def test_no_display_warnings():
+    '''Check that warnings are emitted without for classes, functions, and others'''
+    class NoDisplay(object):
+        pass
+
+    with pytest.warns(MARXSVisualizationWarning) as record:
+        plot_object(NoDisplay())
+
+    # check that only one warning was raised
+    assert len(record) == 1
+    # check that the message matches
+    assert 'No display dictionary found.' in record[0].message.args[0]
+
+    def f():
+        pass
+
+    with pytest.warns(MARXSVisualizationWarning) as record:
+        plot_object(f)
+
+    # check that only one warning was raised
+    assert len(record) == 1
+    # check that the message matches
+    assert 'No display dictionary found.' in record[0].message.args[0]
+
+
+    with pytest.warns(MARXSVisualizationWarning) as record:
+        plot_object(range)
+
+    assert len(record) == 1
+    assert 'No display dictionary found' in record[0].message.args[0]
+
+def test_warning_unknownshape():
+    '''Test warning (and no crash) for plotting stuff of unknown shape.'''
+    class Display():
+        display = {'shape': 'cilinder'}
+
+    with pytest.warns(MARXSVisualizationWarning) as record:
+        plot_object(Display())
+
+    # check that only one warning was raised
+    assert len(record) == 1
+    # check that the message matches
+    assert 'No function to plot cilinder.' in record[0].message.args[0]
+
+def test_warning_noshapeset():
+    '''Test warning (and no crash) for plotting stuff of unknown shape.'''
+    class Display():
+        display = {'form': 'cilinder'}
+
+    with pytest.warns(MARXSVisualizationWarning) as record:
+        plot_object(Display())
+
+    # check that only one warning was raised
+    assert len(record) == 1
+    # check that the message matches
+    assert '"shape" not set in display dict.' in record[0].message.args[0]

--- a/marxs/visualization/utils.py
+++ b/marxs/visualization/utils.py
@@ -16,6 +16,16 @@ class MARXSVisualizationWarning(Warning):
     pass
 
 
+def get_obj_name(obj):
+    '''Return printable name for objects or functions.'''
+    if hasattr(obj, 'name'):
+        return obj.name
+    elif hasattr(obj, 'func_name'):
+        return obj.func_name
+    else:
+        return str(obj)
+
+
 def plot_object_general(plot_registry, obj, display=None, **kwargs):
     '''Look up a plottig routine for an object and execute it.
 
@@ -47,7 +57,7 @@ def plot_object_general(plot_registry, obj, display=None, **kwargs):
         if hasattr(obj, 'display') and (obj.display is not None):
             display = obj.display
         else:
-            warnings.warn('Skipping {0}: No display dictionary found.'.format(obj.name),
+            warnings.warn('Skipping {0}: No display dictionary found.'.format(get_obj_name(obj)),
                            MARXSVisualizationWarning)
             return None
 
@@ -62,10 +72,10 @@ def plot_object_general(plot_registry, obj, display=None, **kwargs):
                 out = plot_registry[s](obj, display,  **kwargs)
                 break
         else:
-            warnings.warn('Skipping {0}: No function to plot {1}'.format(obj.name, shape),
+            warnings.warn('Skipping {0}: No function to plot {1}.'.format(get_obj_name(obj), shape),
                           MARXSVisualizationWarning)
     else:
-        warnings.warn('Skipping {0}: "shape" not set in display dict.'.format(obj.name),
+        warnings.warn('Skipping {0}: "shape" not set in display dict.'.format(get_obj_name(obj)),
                        MARXSVisualizationWarning)
     return out
 


### PR DESCRIPTION
This can be used to mark e.g. the optical axis in a plot or for obscuring support struts (not part of this PR). Includes a few small bug fixes that I discovered while getting this to work. See commit messages for details.