### PR TITLE
Fix polarization vectors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,11 @@ Bug fixes
 - Added missing keywords in display dict for some objects and fixed exception when plotting
   things that are not objects. Discovered and fixed as part of [#147].
 
+- Polarization after reflection from a mirror used to just parallel transport the vector.
+  and calculate the probability of the photon based on s and p polarization. This needs
+  to be applied to the outgoing polarization vector, too. [#148]
+
+
 Other changes and additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Improved Documentation [#146]

--- a/marxs/math/polarization.py
+++ b/marxs/math/polarization.py
@@ -1,5 +1,6 @@
 # Licensed under GPL version 3 - see LICENSE.rst
 import numpy as np
+import astropy.units as u
 
 from .utils import norm_vector, e2h
 
@@ -9,11 +10,11 @@ __all__ = ['polarization_vectors', 'Q_reflection', 'paralleltransport_matrix',
 
 
 def polarization_vectors(dir_array, angles):
-    '''Takes angle polarizations and converts them to vectors in the direction of polarization.
+    '''Converts polarization angles to vectors in the direction of polarization.
 
     Follows convention: Vector perpendicular to photon direction and closest to +y axis is
-    angle 0 for polarization direction, unless photon direction is parallel to the y axis, in
-    which case the vector closest to the +x axis is angle 0.
+    angle 0 for polarization direction, unless photon direction is parallel to the y axis,
+    in which case the vector closest to the +x axis is angle 0.
 
     Parameters
     ----------
@@ -48,6 +49,8 @@ def polarization_vectors(dir_array, angles):
     r = dir_array.copy()[:,0:3]
     r /= np.linalg.norm(r, axis=1)[:, np.newaxis]
     pol_convention_x = np.isclose(r[:,0], 0.) & np.isclose(r[:,2], 0.)
+    if hasattr(angles, "unit") and (angles.unit is not None):
+        angles = angles.to(u.rad)
     # polarization relative to positive y or x at 0
     v_1 = ~pol_convention_x[:, np.newaxis] * (y - r * np.dot(r, y)[:, np.newaxis])
     v_1 += pol_convention_x[:, np.newaxis] * (x - r * np.dot(r, x)[:, np.newaxis])

--- a/marxs/optics/multiLayerMirror.py
+++ b/marxs/optics/multiLayerMirror.py
@@ -26,7 +26,15 @@ class FlatBrewsterMirror(FlatOpticalElement):
     }
 
     def fresnel(self, photons, intersect, intersection, local):
-        '''The incident angle can easily be calculated from e_x and photons['dir'].'''
+        '''The incident angle can easily be calculated from e_x and photons['dir'].
+
+        Returns
+        -------
+        refl_s, refl_p : np.array or float
+            Reflection probability for s and p polarized photons.
+            Typically, the number will depend on the incident angle and energy
+            of each photon and thus the return value will be a vector.
+        '''
         return 1., 0.
 
     def specific_process_photons(self, photons, intersect, intersection, local):

--- a/marxs/optics/multiLayerMirror.py
+++ b/marxs/optics/multiLayerMirror.py
@@ -55,15 +55,16 @@ class FlatBrewsterMirror(FlatOpticalElement):
         p_v_s = np.einsum('ij,ij->i', polarization, v_s)
         p_v_p = np.einsum('ij,ij->i', polarization, v_p)
 
+        fresnel_refl_s, fresnel_refl_p = self.fresnel(photons, intersect, intersection, local)
+        # Calculate new intensity ~ (E_x)^2 + (E_y)^2
+        Es2 = fresnel_refl_s * p_v_s ** 2
+        Ep2 = fresnel_refl_p * p_v_p ** 2
+
         # parallel transport of polarization vector
         # v_s stays the same by definition
         new_v_p = np.cross(h2e(new_beam_dir), v_s)
-        new_pol = -p_v_s[:, np.newaxis] * v_s + p_v_p[:, np.newaxis] * new_v_p
+        new_pol = norm_vector(-Es2[:, np.newaxis] * v_s  + Ep2[:, np.newaxis] * new_v_p)
 
-        fresnel_refl_s, fresnel_refl_p = self.fresnel(photons, intersect, intersection, local)
-        # Calculate new intensity ~ (E_x)^2 + (E_y)^2
-        Es2 = fresnel_refl_s * np.einsum('ij,ij->i', polarization, v_s) ** 2
-        Ep2 = fresnel_refl_p * np.einsum('ij,ij->i', polarization, v_p) ** 2
 
         return {'dir': new_beam_dir,
                 'probability': Es2 + Ep2,

--- a/marxs/optics/tests/test_mlMirror.py
+++ b/marxs/optics/tests/test_mlMirror.py
@@ -12,45 +12,57 @@ def test_photon_reflection():
     TODO: This test should be broken down into smaller components, as should the
     multilayer mirror process photons function.
     '''
-    pos = np.array([[1., 0., 0., 1],
-                    [1., 0., 0., 1],
-                    [1., 0., 0., 1]])
+    pos = np.tile([1.,0.,0.,1.], (4,1))
     # hitting y = 23mm, 26mm, 24mm; std dev = 0.02, 0.04, 0.01; max = 5.81, 0.42, 6.21; lambda = 3, 6, 4
     dir = np.array([[-1., -1.5, 0., 0],
                     [-1., 1.5, 0., 0],
-                    [-1., -0.5, 13., 0]])
+                    [-1., -0.5, 13., 0],
+                    [-1., -1.5, 0., 0]])
     # note: these photons will not hit at 45 degrees (only ok for testing purposes)
     polarization = np.array([[0., 0., 1., 0],
                              [1., 0., 0., 0],
-                             [1., 0., 0., 0]])
+                             [1., 0., 0., 0],
+                             [1. / np.sqrt(2.), 0., 1. / np.sqrt(2.), 0.]])
     # z axis is the parallel polarization, v_1, so crossing that with direction (perpendicular to z) is v_2
     polarization[1, 0:3] = np.cross(dir[1,0:3], polarization[0,0:3])
     polarization[1, 0:3] /= np.linalg.norm(polarization[1,0:3])
 
     photons = Table({'pos': pos,
                      'dir': dir,
-                     'energy': [1.23984282 / 3.02, 1.23984282 / 6, 0.4],
-                     'polarization': polarization, 'probability': [1., 1., 1.]})
+                     'energy': [1.23984282 / 3.02, 1.23984282 / 6, 0.4,
+                                1.23984282 / 3.02],
+                     'polarization': polarization,
+                     'probability': [1., 1., 1., 1.]})
     mirror = MultiLayerMirror(reflFile='./marxs/optics/data/testFile_mirror.txt', testedPolarization='./marxs/optics/data/ALSpolarization2.txt', zoom=[1, 24.5, 12])
     photons = mirror(photons)
 
     # confirm reflection angle
-    expected_dir = norm_vector(np.array([[1., -1.5, 0., 0], [1., 1.5, 0., 0], [-1., -0.5, 13., 0]]))
+    expected_dir = norm_vector(np.array([[1., -1.5, 0., 0],
+                                         [1., 1.5, 0., 0],
+                                         [-1., -0.5, 13., 0],
+                                         [1., -1.5, 0., 0]]))
     assert np.allclose(norm_vector(np.array(photons['dir'])), expected_dir)
 
     # confirm reflection probability
     polarizedFile = ascii.read('./marxs/optics/data/ALSpolarization2.txt')
-    correctTestPolar = np.interp(1.23984282 / 3.02, polarizedFile['Photon energy'] / 1000, polarizedFile['Polarization'])
-    expected_prob = np.array([0.0581 * np.exp(-0.5) * 1. / correctTestPolar, 0.0042 * 0., 1.])
+    correctTestPolar = np.interp(1.23984282 / 3.02,
+                                 polarizedFile['Photon energy'] / 1000,
+                                 polarizedFile['Polarization'])
+    expected_prob = np.array([0.0581 * np.exp(-0.5) * 1. / correctTestPolar,
+                              0.0042 * 0.,
+                              1.,
+                              0.5 * 0.0581 * np.exp(-0.5) * 1. / correctTestPolar])
     assert np.allclose(photons['probability'], expected_prob)
 
     # confirm correct new polarization
-    expected_pol = norm_vector(np.array([[0., 0, 1., 0], [1., 1.5, 0., 0]]))
-    expected_pol[1,0:3] = np.cross(photons['dir'][1,0:3] / np.linalg.norm(photons['dir'][1,0:3]), expected_pol[0,0:3])
+    expected_pol = np.array([0., 0, 1., 0])
     simulated_pol = norm_vector(photons['polarization'])
-    for i in [0, 1]:
-        assert (np.allclose(simulated_pol[i], expected_pol[i]) or
-                np.allclose(simulated_pol[i], -expected_pol[i]))
+    for i in [0, 3]:
+        assert (np.allclose(simulated_pol[i], expected_pol) or
+                np.allclose(simulated_pol[i], -expected_pol))
+    # prob of relfection is 0, so pol direction is undefined.
+    assert np.all(np.isnan(simulated_pol[1][:3]))
+
 
 def test_photon_reflection2():
     '''more rigorous reflection test'''

--- a/marxs/source/pointing.py
+++ b/marxs/source/pointing.py
@@ -138,11 +138,13 @@ class FixedPointing(PointingModel):
         photonsdir : np.array of shape (n, 4)
             Direction of photons
         polangle : np.array
-            Polarization angle in degree measured N through E.
+            Polarization angle measured N through E. If polangle has no
+            units, it is assumed to be specified in radian.
         time : np.array
             Time for each photons in sec
         '''
-        polangle = np.deg2rad(polangle)
+        if hasattr(polangle, "unit") and (polangle.unit is not None):
+            polangle = polangle.to(u.rad)
         north = SkyCoord(0., 90., unit='deg', frame=self.coords)
         northdir = e2h(north.transform_to(self.offset_coos).cartesian.xyz.T, 0)
         northdir = np.dot(self.reference_transform, northdir)

--- a/marxs/source/source.py
+++ b/marxs/source/source.py
@@ -100,8 +100,8 @@ class Source(SimulationSequenceElement):
           second column is the flux density.
           Given this table, the code assumes a piecewise flat spectrum. The "energy"
           values contain the **upper** limit of each bin, the "flux" array the flux density
-          in each bin. The first entry in the "flux" array is ignored, because the lower bound
-          of this bin is undefined.
+          in each bin. The first entry in the "flux" array is ignored, because the lower
+          bound of this bin is undefined.
           The code draws an energy from this spectrum for every photon created.
         - A function or callable object: This option allows for full customization. The
           function must take an array of photon times as input and return an equal length
@@ -109,7 +109,7 @@ class Source(SimulationSequenceElement):
 
     polarization: contant or ``None``, (2, N) `numpy.ndarray`, `dict <dict>`, `astropy.table.Table` or similar or callable.
         There are several different ways to set the polarization angle of the photons for a
-        polarized source. In all cases, the angle is given in degrees and is measured North
+        polarized source. In all cases, the angle is measured North
         through East. (We ignore the special case of a polarized source exactly on a pole.)
         The default value is ``None`` (unpolarized source).
 
@@ -197,7 +197,7 @@ class Source(SimulationSequenceElement):
             rand = RandomArbitraryPdf(self.polarization['angle'], self.polarization['probability'])
             return rand(n)
         elif self.polarization is None:
-            return np.random.uniform(0, 360., n)
+            return np.random.uniform(0, 2 * np.pi, n)
         else:
             raise SourceSpecificationError('`polarization` must be number (angle), callable, None (unpolarized), 2.n array or have fields "angle" (in rad) and "probability".')
 
@@ -244,7 +244,7 @@ class Source(SimulationSequenceElement):
                                    'Host system running simulation')
         photons['time'].unit = u.s
         photons['energy'].unit = u.keV
-        photons['polangle'].unit = u.degree
+        photons['polangle'].unit = u.rad
         return photons
 
 

--- a/marxs/source/tests/test_pointing.py
+++ b/marxs/source/tests/test_pointing.py
@@ -29,7 +29,7 @@ def test_polarization_direction():
     '''Test that a FixedPointing correctly assigns linear polarization vectors.'''
     s = PointSource(coords=SkyCoord(187.4, 0., unit='deg'))
     photons = s.generate_photons(5)
-    photons['polangle'] = [0., 90., 180., 270., 45.]
+    photons['polangle'] = (np.array([0., 90., 180., 270., 45.])) * u.deg.to(photons['polangle'].unit)
     point_x = FixedPointing(coords=SkyCoord(187.4, 0., unit='deg'))
     p_x = point_x(photons.copy())
     # For a simple polangle 0 = 180 and the direction does not matter.
@@ -53,7 +53,7 @@ def test_polarization_direction():
     s = PointSource(coords=SkyCoord(22.5, 0., unit='deg'))
     photons = s.generate_photons(5)
     photons['dec'] = [67., 23., 0., -45.454, -67.88]
-    photons['polangle'] = 90.
+    photons['polangle'] = (90. * u.deg).to(photons['polangle'].unit)
     point = FixedPointing(coords=SkyCoord(94.3, 23., unit='deg'))
     p = point(photons.copy())
     for i in range(1, len(p)):


### PR DESCRIPTION
In the old scheme polarization vectors were just parallel transported when reflecting off
a surface and the probability was adjusted according to their direction.
However, if the probability for s and p polarized photons is different (e.g. for the
Brewster angle the probability for p reflected photons must indeed be 0), then
you might end up with a polarization vector that contains both s and p polarized
components, even though the probability to reflect p photons should be 0.
    
In this fix, polarization vectors are modified when reflected.
