### PR TITLE
Remove tuple instead of SkyCoord for input in pointing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,26 +8,34 @@ New Features
 API Changes
 ^^^^^^^^^^^
 - Remove ``marxs.sources.LabPointSource``, which was just a special case of
-  `~marxs.sources.LabPointSourceCone`. Instead, set the default values of the later
-  so that it reproduces the behaviour of the former. [#144]
+  `~marxs.sources.LabPointSourceCone`. Instead, set the default values of the
+  later so that it reproduces the behaviour of the former. [#144]
 
-- `~marxs.optics.MultiLayerEfficiency` and `~marxs.optics.MultiLayerMirror` now expect
-  all parameters as keyword arguments for consistency with the other elements in MARXS.
-  [#144]
+- `~marxs.optics.MultiLayerEfficiency` and `~marxs.optics.MultiLayerMirror` now
+  expect all parameters as keyword arguments for consistency with the other
+  elements in MARXS. [#144]
 
 - ``marxs.visualization.utils.format_saved_positions`` is now a method of
   `~marxs.simulator.KeepCol` with the new name ``to_array()`` and the ``atol``
   keyword can be switched off. This makes the function useful for columns that
   are not positions, but e.g. polarization vectors. [#149]
 
+- According to the docs, a pointing could be initialized with either a 
+  `~astropy.coordiantes.SkyCoord` or a tuple that would initialize the
+  `~astropy.coordiantes.SkyCoord`. The later option was broken and has 
+  been removed entirely. [#151]
+
 Bug fixes
 ^^^^^^^^^
-- Added missing keywords in display dict for some objects and fixed exception when plotting
-  things that are not objects. Discovered and fixed as part of [#147].
+- Added missing keywords in display dict for some objects and fixed exception
+  when plotting things that are not objects. Discovered and fixed as part of
+  [#147].
 
-- Polarization after reflection from a mirror used to just parallel transport the vector.
-  and calculate the probability of the photon based on s and p polarization. This needs
-  to be applied to the outgoing polarization vector, too. [#148]
+- Polarization after reflection from a mirror used to just parallel transport
+  the vector and calculate the probability of the photon based on s and p
+  polarization. This needs to be applied to the outgoing polarization vector,
+  too. [#148]
+
 
 
 Other changes and additions
@@ -36,8 +44,10 @@ Other changes and additions
 
 1.0 (14-Apr-2017)
 -----------------
-This is the first release intended to use. The Change log will begin starting with this release.
+This is the first release intended to use. The Change log will begin starting 
+with this release.
 
 0.1 (experimental release)
 --------------------------
-This release was not intended to be used, but the verisioning scheme in the development branch required a tagged commit.
+This release was not intended to be used, but the verisioning scheme in the 
+development branch required a tagged commit.

--- a/marxs/optics/marx.py
+++ b/marxs/optics/marx.py
@@ -2,12 +2,6 @@
 '''
 .. todo::
    Add a mechanism for unit conversion. This expects all distances in mm and all energies in keV.
-
-.. todo::
-   Do something about the effective areas. Can be read out after mirror is initialized.
-
-.. todo::
-   Make a setup.py parameter for the marxsource code and marx compiled binary location
 '''
 import os
 import numpy as np

--- a/marxs/source/pointing.py
+++ b/marxs/source/pointing.py
@@ -2,7 +2,6 @@
 import numpy as np
 from astropy.table import Column
 import astropy.units as u
-import astropy.coordinates as coord
 from astropy.coordinates import SkyCoord
 
 from ..base import SimulationSequenceElement
@@ -52,11 +51,8 @@ class FixedPointing(PointingModel):
 
     Parameters
     ----------
-    coords : `astropy.coordinates.SkySoord` (preferred)
-        Position of the source on the sky. If ``coords`` is not a
-        `~astropy.coordinates.SkyCoord` object itself, it is used to
-        initialize such an object. See `~astropy.coordinates.SkyCoord`
-        for a description of allowed input values.
+    coords : `astropy.coordinates.SkySoord`
+        Position of the source on the sky.
     roll : `~astropy.units.quantity.Quantity`
         ``roll = 0`` means: z axis points North (measured N -> E).
     reference_transform : np.array of shape (4, 4)
@@ -87,12 +83,7 @@ class FixedPointing(PointingModel):
     determines the position of the coordinate system.
     '''
     def __init__(self, **kwargs):
-        coords = kwargs.pop('coords')
-        if isinstance(coords, coord.SkyCoord):
-            self.coords = coords
-        else:
-            self.coords = coord.SkyCoord(coords)
-
+        self.coords = kwargs.pop('coords')
         if not self.coords.isscalar:
             raise ValueError("Coordinate must be scalar, not array.")
         self.roll = kwargs.pop('roll', 0. * u.rad)


### PR DESCRIPTION
According to the docs, a pointing could be initialized with either a
`~astropy.coordiantes.SkyCoord` or a tuple that would initialize the
`~astropy.coordiantes.SkyCoord`. The later option was broken and has
been removed entirely.