### PR TITLE
Rename to_array method of KeepCol back to format_positions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,9 +16,14 @@ API Changes
   elements in MARXS. [#144]
 
 - ``marxs.visualization.utils.format_saved_positions`` is now a method of
-  `~marxs.simulator.KeepCol` with the new name ``to_array()`` and the ``atol``
-  keyword can be switched off. This makes the function useful for columns that
-  are not positions, but e.g. polarization vectors. [#149]
+  `~marxs.simulator.KeepCol` with the new name ``format_positions()`` and
+  the ``atol`` keyword can be switched off.
+  Additionally, `~marxs.simulator.KeepCol` now has a ``__array__`` method.
+  This makes the function useful for columns that
+  are not positions, but e.g. polarization vectors.
+  On the other hand, the ``plot_rays`` functions do not accept
+  `~marxs.simulator.KeepCol` objects directly as input any longer.
+  [#149, #152]
 
 - According to the docs, a pointing could be initialized with either a 
   `~astropy.coordiantes.SkyCoord` or a tuple that would initialize the

--- a/docs/visualization.rst
+++ b/docs/visualization.rst
@@ -99,7 +99,7 @@ Another changes compared to the 2d plotting is that we generate a lot fewer phot
   >>> photons = pointing(photons)
   >>> photons = instrum(photons)
   >>> ind = (photons['probability'] > 0) & (photons['facet'] >=0)
-  >>> posdat = pos.to_array()[ind, :, :]
+  >>> posdat = pos.format_positions()[ind, :, :]
   >>> fig = mlab.figure()
   >>> obj = plot_object(instrum, viewer=fig)
   >>> rays = plot_rays(posdat, scalar=photons['energy'][ind])

--- a/marxs/simulator/simulator.py
+++ b/marxs/simulator/simulator.py
@@ -440,13 +440,18 @@ class KeepCol(object):
         else:
             self.data.append(photons[self.colname].copy())
 
+    def __array__(self):
+        return np.stack(self.data)
 
-    def to_array(self, atol=None):
+    def format_positions(self, atol=None):
         '''Format saved position columns as a single array.
 
         `KeepCol` keeps the value of a column (e.g. the photon position)
         at every step of the simulation. This function reformats that list of
-        columns for use graphical display programs.
+        columns for use graphical display programs. Note that `format_positions`
+        will only work for columns that store data in homogeneous coordinates,
+        for all other cases, simply call `numpy.asanyarray` on your `KeepCol`
+        object.
 
         Parameters
         ----------
@@ -466,6 +471,8 @@ class KeepCol(object):
         '''
         if len(self.data) == 0:
             raise ValueError('KeepCol object contains no data.')
+        if not self.data[0].ndim == 2 or self.data[0].shape[1] !=4:
+            raise ValueError('format_position only works for columns that store homogeneous coordinates.')
         d = np.dstack(self.data)
         d = np.swapaxes(d, 1, 2)
         d = h2e(d)

--- a/marxs/simulator/tests/test_simulator.py
+++ b/marxs/simulator/tests/test_simulator.py
@@ -1,4 +1,5 @@
 import numpy as np
+from astropy.table import Table
 import pytest
 
 from ..simulator import KeepCol
@@ -11,18 +12,35 @@ def test_format_saved_positions():
     pos = KeepCol('testcase')
     pos.data = [pos0, pos1, pos2]
 
-    d = pos.to_array(atol=1e-2)
+    d = pos.format_positions(atol=1e-2)
     assert d.shape == (5, 2, 3)
     assert np.allclose(d[0, 0, :], [0, 1./3, 2./3])
 
     '''Not drop values'''
-    d = pos.to_array()
+    d = pos.format_positions()
     assert d.shape == (5, 3, 3)
 
 def test_empty_format_saved_positions():
     '''If the input contains no data, an error should be raised.'''
     a = KeepCol('testcase')
     with pytest.raises(ValueError) as e:
-        d = a.to_array()
+        d = a.format_positions()
 
     assert 'contains no data' in str(e.value)
+
+def test_format_save_positions_fails():
+    '''Can only be used when data is in homogenous coordiantes.'''
+    a = KeepCol('testcase')
+    a.data = [np.arange(5), np.arange(5)]
+    with pytest.raises(ValueError) as e:
+        d = a.format_positions()
+
+    assert 'homogeneous coordinates' in str(e.value)
+
+def test_to_array():
+    a = KeepCol('testcase')
+    col1 = Table([[1]], names=['testcase'])
+    col2 = Table([[4]], names=['testcase'])
+    a(col1)
+    a(col2)
+    assert np.all(np.sqrt(a) == [[1.], [2.]])

--- a/marxs/visualization/mayavi.py
+++ b/marxs/visualization/mayavi.py
@@ -112,10 +112,9 @@ def plot_rays(data, scalar=None, viewer=None,
 
     Parameters
     ----------
-    data : np.array of shape(n, N, 3) or `marxs.simulator.KeepCol` object
+    data : np.array of shape(n, N, 3)
         where n is the number of rays, N the number of positions per ray and
         the last dimension is the (x,y,z) of an Eukledian position vector.
-        This can also be a ``KeepCol('pos')`` object.
     scalar : None or nd.array of shape (n,) or (n, N)
         This quantity is used to color the rays. If ``None`` all rays will have the same
         color. If it has n elements, each ray will have exactly one color (e.g. color
@@ -136,9 +135,6 @@ def plot_rays(data, scalar=None, viewer=None,
         This just passes through the information returned from the mayavi calls.
     '''
     from mayavi import mlab
-
-    if hasattr(data, 'data') and isinstance(data.data, list):
-        data = utils.format_saved_positions(data)
 
     # The number of points per line
     N = data.shape[1]

--- a/marxs/visualization/threejs.py
+++ b/marxs/visualization/threejs.py
@@ -92,9 +92,6 @@ def materialspec(display, material):
     return ', '.join(spec)
 
 def _format_plot_rays_input(data, scalar, cmap, prop):
-    if hasattr(data, 'data') and isinstance(data.data, list):
-        data = utils.format_saved_positions(data)
-
     # The number of points per line
     N = data.shape[1]
     # number of lines
@@ -125,10 +122,9 @@ def plot_rays(data, outfile, scalar=None, cmap=None,
 
     Parameters
     ----------
-    data : np.array of shape(n, N, 3) or `marxs.simulator.KeepCol` object
+    data : np.array of shape(n, N, 3)
         where n is the number of rays, N the number of positions per ray and
         the last dimension is the (x,y,z) of an Eukledian position vector.
-        This can also be a ``KeepCol('pos')`` object.
     scalar : None or nd.array of shape (n,) or (n, N)
         This quantity is used to color the rays. If ``None`` all rays will have the same
         color. If it has n elements, each ray will have exactly one color (e.g. color

--- a/marxs/visualization/threejsjson.py
+++ b/marxs/visualization/threejsjson.py
@@ -163,10 +163,9 @@ def plot_rays(data, scalar=None, prop={}, name='Photon list', cmap=None):
 
     Parameters
     ----------
-    data : np.array of shape(n, N, 3) or `marxs.simulator.KeepCol` object
+    data : np.array of shape(n, N, 3)
         where n is the number of rays, N the number of positions per ray and
         the last dimension is the (x,y,z) of an Eukledian position vector.
-        This can also be a ``KeepCol('pos')`` object.
     scalar : None or nd.array of shape (n,) or (n, N)
         This quantity is used to color the rays. If ``None`` all rays will have the same
         color. If it has n elements, each ray will have exactly one color (e.g. color
@@ -183,7 +182,6 @@ def plot_rays(data, scalar=None, prop={}, name='Photon list', cmap=None):
         can be specified in this keyword.
     '''
     data, s_rgb, prob, n = threejs._format_plot_rays_input(data, scalar, cmap, prop)
-
 
     out = {}
     out['n'] = n


### PR DESCRIPTION
The code in there is position specific, that is uses h2e etc. so that
should be obvious from the name. Also, it now throws exceptions if it does
not look like positional data.

Added a __array__ mathod to make converting other stuff to numpy arrays
easier.