### PR TITLE
Remove parameter filterfunc from analysis scripts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,10 @@ API Changes
   `~astropy.coordiantes.SkyCoord`. The later option was broken and has 
   been removed entirely. [#151]
 
+- Remove parameter ``filterfunc`` from `~marxs.analysis.gratings.resolvingpower_from_photonlist` and `~marxs.analysis.analysis.detected_fraction`.
+  Instead, the photon list can be filtered before calling these functions
+  just as easily. [#159]
+
 Bug fixes
 ^^^^^^^^^
 - Added missing keywords in display dict for some objects and fixed exception

--- a/marxs/analysis/analysis.py
+++ b/marxs/analysis/analysis.py
@@ -21,14 +21,15 @@ def sigma_clipped_std(data, **kwargs):
     return std
 
 
-def find_best_detector_position(photons, col='det_x', objective_func=sigma_clipped_std,
+def find_best_detector_position(photons, col='det_x',
+                                objective_func=sigma_clipped_std,
                                 orientation=np.eye(3), **kwargs):
-    '''Numerically optimize the position of a detector to find the position of best focus.
+    '''Numerically find the position of best focus.
 
-    This routine places detectors at different positions and calculates the width of the
-    photon distribution for each position.
-    As a side effect, ``photons`` will be set to the intersection with the last try of
-    the detector position.
+    This routine places detectors at different positions and
+    calculates the width of the photon distribution for each position.
+    As a side effect, ``photons`` will be set to the intersection with
+    the last try of the detector position.
 
     Parameters
     ----------
@@ -37,19 +38,19 @@ def find_best_detector_position(photons, col='det_x', objective_func=sigma_clipp
     col : string
         Column name of the photon distribution to be minimized.
         The default is set for detectors that look for a grating signal
-        (which is dispersed in ``det_y
-    `` direction).
+        (which is dispersed in ``det_y`` direction).
     objective_func : function
         Function that accepts a np.array as input and return the width.
     rotation : np.array of shape (3,3)
-        Rotation matrix for the detector. By default the detector is parallel to the yz plane
-        of the global coordinate system (see `pos4d`).
+        Rotation matrix for the detector. By default the detector is parallel
+        to the yz plane of the global coordinate system (see `pos4d`).
     kwargs : see `scipy.optimize.minimize`
         All other keyword argument will be passed to `scipy.optimize.minimize`.
     Returns
     -------
     opt : OptimizeResult
         see `scipy.optimize.minimize`
+
     '''
     def width(x, photons):
         mdet = FlatDetector(position=np.array([x, 0, 0]), orientation=orientation, zoom=1e5, pixsize=1.)
@@ -60,8 +61,7 @@ def find_best_detector_position(photons, col='det_x', objective_func=sigma_clipp
                                    **kwargs)
 
 
-
-def detected_fraction(photons, labels, filterfunc=None, col='order'):
+def detected_fraction(photons, labels, col='order'):
     '''Calculate the fraction of photons detected for some integer label
 
     While written for calculating Aeff per order, this can be used with any discrete
@@ -73,12 +73,8 @@ def detected_fraction(photons, labels, filterfunc=None, col='order'):
         Photon event list
     labels : np.array
         Numeric (integer) labels that are found in column ``col``. When, e.g.,
-        the effective area per order is calculated, this array should contain the
-        order numbers for which the calculation will be done.
-    filterfunc : callable or ``None``
-        If not ``None``, a function that takes the photon table and returns an
-        index array. This can be used, e.g. filter out photons that hit particular CCDs or
-        hot columns.
+        the effective area per order is calculated, this array should contain
+        the order numbers for which the calculation will be done.
     col : string
         Column name for the order column.
 

--- a/marxs/analysis/gratings.py
+++ b/marxs/analysis/gratings.py
@@ -162,7 +162,7 @@ def weighted_per_order(data, orders, energy, gratingeff):
     return np.ma.average(data, axis=0, weights=weights)
 
 
-def resolvingpower_from_photonlist(photons, orders, filterfunc=None,
+def resolvingpower_from_photonlist(photons, orders,
                                    col='proj_x', zeropos=None,
                                    ordercol='order'):
     '''Calculate the resolving power for several grating orders
@@ -180,10 +180,6 @@ def resolvingpower_from_photonlist(photons, orders, filterfunc=None,
         Photon event list
     orders : np.array
         Orders for which the resolving power will be calculated
-    filterfunc : callable or ``None``
-        If not ``None``, a function that takes the photon table and returns an
-        index array. This can be used, e.g. filter out photons that hit
-        particular CCDs or hot columns.
     col : string
         Column name for the column holding the dispersion coordinate.
     zeropos : float or ``None``
@@ -215,9 +211,6 @@ def resolvingpower_from_photonlist(photons, orders, filterfunc=None,
 
     for i, o in enumerate(orders):
         ind = (photons[ordercol] == o)
-        if filterfunc is not None:
-            ind = ind & filterfunc(photons)
-
         if ind.sum() > 20:
             meanpos, medianpos, stdpos = sigma_clipped_stats(photons[col][ind])
         else:


### PR DESCRIPTION
Remove parameter ``filterfunc`` from
`~marxs.analysis.gratings.resolvingpower_from_photonlist` and
`~marxs.analysis.analysis.detected_fraction`.
Instead, the photon list can be filtered before calling these functions
just as easily. [#159]

[closes #155]