### PR TITLE
Update .travis.yml to not specify TRAVIS_OS_NAME when running ci-helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
     # commands in the install: section below.
 
     - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - source ci-helpers/travis/setup_conda.sh
 
     # As described above, using ci-helpers, you should be able to set up an
     # environment with dependencies installed using conda and pip, but in some


### PR DESCRIPTION
Hi there :wave:, it looks like you are using ci-helpers in your Travis configuration. This is an automated update made by the maintainers of ci-helpers - we have now made it so that it is no longer necessary to include the ``$TRAVIS_OS_NAME`` variable here:

    source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh

Instead you can now use:

    source ci-helpers/travis/setup_conda.sh

This adds some new functionality, including the ability to run certain builds only for certain event types (``push``, ``cron``, etc.) using the ``$EVENT_TYPE`` variable, and skipping only Travis builds using ``[skip travis]`` in commit messages. See the [README](https://github.com/astropy/ci-helpers/blob/master/README.md) for ci-helpers for more information on these options.

Note that for environmental :leaves: reasons, we have added ``[skip appveyor]`` to the commit message to avoid running AppVeyor for repositories that use it.

If you do not want to make this change, feel free to close the pull request

Thanks! :robot: :wave:

*If there are issues with this pull request, please ping ``@astrofrog``*