### PR TITLE
Update astropy-helpers to v2.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,8 +86,6 @@ matrix:
           env: SETUP_CMD='build_sphinx -w'
 
         # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development
         - python: 3.5
           env: ASTROPY_VERSION=development
         # - python: 2.7

--- a/marxs/visualization/mayavi.py
+++ b/marxs/visualization/mayavi.py
@@ -38,8 +38,8 @@ doc_plot='''
         source: the source can only be used for testing, or numerical algorithms,
         not visualization.
 
-    Parameters
-    ----------
+    Returns
+    -------
     out : mayavi object
         Return the result of a mayavi plotting method.
 '''

--- a/marxs/visualization/mayavi.py
+++ b/marxs/visualization/mayavi.py
@@ -206,8 +206,8 @@ def plot_object(obj, display=None, viewer=None, **kwargs):
         All other parameters will be passed on to the individual plotting
         method.
 
-    Parameters
-    ----------
+    Returns
+    -------
     out : mayavi object
         Return the result of a mayavi plotting method.
 


### PR DESCRIPTION
This is an automated update of the astropy-helpers submodule to v2.0.2. This includes both the update of the astropy-helpers sub-module, and the ``ah_bootstrap.py`` file, if needed.

*This is intended to be helpful, but if you would prefer to manage these updates yourself, or if you notice any issues with this automated update, please let @bsipocz or @astrofrog know!*