### PR TITLE
Add method move_center to simulator.Parallel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,13 +3,18 @@
 
 New Features
 ^^^^^^^^^^^^
+- Unit milimeter on ``"pos"`` and ``"dir"`` columns of photonlist [#169].
+
+- Add method `marxs.simulator.Parallel.move_center` to change the ``pos4d``
+  value of a `marxs.simulator.Parallel` and adjust position of elements at
+  the same time [#169].
 
 API Changes
 ^^^^^^^^^^^
 
 Bug fixes
 ^^^^^^^^^
-- `marxs.analysis.grating.resolvingpower_per_order` has been updated to ignore
+- `marxs.analysis.gratings.resolvingpower_per_order` has been updated to ignore
   photons with probability 0. [#162]
 
 - An index mix-up in `marxs.simulator.ParallelCalculated.calculate_elempos` introduced
@@ -33,11 +38,12 @@ New Features
 
 API Changes
 ^^^^^^^^^^^
-- Remove ``marxs.sources.LabPointSource``, which was just a special case of
-  `~marxs.sources.LabPointSourceCone`. Instead, set the default values of the
+- Remove ``marxs.source.LabPointSource``, which was just a special case of
+  `~marxs.source.LabPointSourceCone`. Instead, set the default values of the
   later so that it reproduces the behaviour of the former. [#144]
 
-- `~marxs.optics.MultiLayerEfficiency` and `~marxs.optics.MultiLayerMirror` now
+- `~marxs.optics.multiLayerMirror.MultiLayerEfficiency` and
+  `~marxs.optics.multiLayerMirror.MultiLayerMirror` now
   expect all parameters as keyword arguments for consistency with the other
   elements in MARXS. [#144]
 

--- a/marxs/optics/aperture.py
+++ b/marxs/optics/aperture.py
@@ -25,6 +25,7 @@ class BaseAperture(object):
         photoncoords = table.Column(name='pos', length=len(photons), shape=(4,))
         photons.add_column(photoncoords)
         photons['pos'][:, 3] = 1
+        photons['pos'].unit = u.mm
 
     @property
     def area(self):

--- a/marxs/optics/grating.py
+++ b/marxs/optics/grating.py
@@ -108,22 +108,24 @@ class FlatGrating(FlatOpticalElement):
         grating period variation. The callable has to return a vector of lengths N
         that contains the grating constant for each photon in mm.
     order_selector : callable
-        A function or callable object that accepts arrays of photon energy, polarization
-        and the blaze angle
-        as input and returns arrays for grating order (integer)
-        and probability (float). The probabiliy expresses the chance that the photon passes
-        the grating and is not absorbed, e.g. if the probability that a photon at energy E ends
-        up in order=[-2, -1, 0, 1, 2] is [0, 0, .5, .3, .0] , then the returned probability for
-        all photons should be 0.8.
+        A function or callable object that accepts arrays of photon
+        energy, polarization and the blaze angle as input and returns
+        arrays for grating order (integer) and probability
+        (float). The probabiliy expresses the chance that the photon
+        passes the grating and is not absorbed, e.g. if the
+        probability that a photon at energy E ends up in order=[-2,
+        -1, 0, 1, 2] is [0, 0, .5, .3, .0] , then the returned
+        probability for all photons should be 0.8.
     transmission : bool
         Set to ``True`` for a transmission grating and to ``False`` for a
         reflection grating. (*Default*: ``True`` )
     groove_angle : float
-        Angle between the local z axis and the direction of the grooves in radian.
-        (*Default*: ``0.``)
+        Angle between the local z axis and the direction of the
+        grooves in radian.  (*Default*: ``0.``)
 
     .. warning::
        Reflection gratings are untested so far!
+
     '''
 
     loc_coos_name = ['grat_y', 'grat_z']
@@ -133,21 +135,24 @@ class FlatGrating(FlatOpticalElement):
         '''Set sign convention for grating orders.
 
         This sets the following, somewhat arbitrary convention:
-        Positive grating orders will are displaced along the local :math:`\hat e_z` vector,
-        negative orders in the opposite direction. If the grating is rotated by :math:`-\pi`
-        the physical situation is the same, but the sign of the grating order will be reversed.
-        In this sense, the convention chosen is arbitrarily. However, it has some practical
-        advantages: The implementation is fast and all photons passing through the grating
-        in the same diffraction order are displaced in the same way. (Contrary to the
-        convention in :class:`CATGrating`.)
-        ``order_sign_convention`` has to be a callable that accepts an array
-        of eukledian direction vectors as input and returns ``+1``, ``-1``,
-        or an array filled with ``-1`` or ``+1``.
+        Positive grating orders will are displaced along the local
+        :math:`\hat e_z` vector, negative orders in the opposite
+        direction. If the grating is rotated by :math:`-\pi` the
+        physical situation is the same, but the sign of the grating
+        order will be reversed.  In this sense, the convention chosen
+        is arbitrarily. However, it has some practical advantages: The
+        implementation is fast and all photons passing through the
+        grating in the same diffraction order are displaced in the
+        same way. (Contrary to the convention in :class:`CATGrating`.)
+        ``order_sign_convention`` has to be a callable that accepts an
+        array of eukledian direction vectors as input and returns
+        ``+1``, ``-1``, or an array filled with ``-1`` or ``+1``.
 
         Parameters
         ----------
         p : np.array
             Array of Eucleadian direction vectors
+
         '''
         # -1 because n, l, d should be right-handed coordinate system
         # while n = e_x, l = e_x, and d = e_y would be left-handed.

--- a/marxs/simulator/tests/test_parallel.py
+++ b/marxs/simulator/tests/test_parallel.py
@@ -1,6 +1,7 @@
 # Licensed under GPL version 3 - see LICENSE.rst
 import numpy as np
 from transforms3d.affines import decompose
+from transforms3d.euler import euler2mat
 
 from ...utils import generate_test_photons
 from .. import Parallel, ParallelCalculated
@@ -20,6 +21,41 @@ def test_Parallel_numbering():
     photons = generate_test_photons(5)
     photons = detect(photons)
     assert np.all(photons['CCD_ID'] == 3.)
+
+def test_Parallel_moving():
+    '''Test moving center of structure after generation.
+    '''
+    pos = [[0, -10.1, -10.1],[0, .1, -10.1],[0, -10.1, .1],[0, .1, .1]]
+    detkwargs = {'elem_class': CCD,
+                 'elem_args': {'pixsize': 0.01, 'zoom': 5},
+                 'elem_pos': {'position': pos},
+                 'id_col': 'CCD_ID',
+                 }
+    detect = Parallel(**detkwargs)
+    detect1 = Parallel(**detkwargs)
+
+    move = np.eye(4)
+    move[2, 3] = 15
+
+    detect1.move_center(move)
+
+    # Check that the default positions are the same
+    for i in range(len(detect.elements)):
+        assert np.allclose(detect.elements[i].pos4d,
+                           detect1.elements[i].pos4d)
+
+    # but rotations are applied around a different point
+    rot = np.eye(4)
+    rot[:3, :3] = euler2mat(.3, .2, 1.2)
+    detect.uncertainty = rot
+    detect.generate_elements()
+
+    detect1.uncertainty = rot
+    detect1.generate_elements()
+
+    for i in range(len(detect.elements)):
+        assert ~np.allclose(detect.elements[i].pos4d,
+                            detect1.elements[i].pos4d)
 
 def test_Parallel_offset_numbering():
     '''The randomly generated positions might generate overlapping elements,

--- a/marxs/source/pointing.py
+++ b/marxs/source/pointing.py
@@ -31,6 +31,7 @@ class PointingModel(SimulationSequenceElement):
         linecoords = Column(name='dir', length=len(photons),
                             shape=(4,))
         photons.add_column(linecoords)
+        photons['dir'].unit = u.mm
         # Leave everything unset, but chances are I will forget the 4th
         # component. Play safe here.
         photons['dir'][:, 3] = 0


### PR DESCRIPTION
This method can move the relative origin of the coordinate system.
Individual element positions in ``elem_pos`` are relative to the global ``pos4d`` of this object. This function changes the ``pos4d`` and adjusts the ``elem_pos`` accordingly, so that the elements still have the same position in global coordinates.

This function is useful when studying uncertainties. The attribute ``uncertainty`` can be used to apply the same change to all elements. Any rotation will be applied around the reference position contained in ``pos4d``. Use this function to change that reference position.