### PR TITLE
Plot active surfaces

### DIFF
--- a/docs/conventions.rst
+++ b/docs/conventions.rst
@@ -31,8 +31,15 @@ All optical elements have some default location and position. Typically, their a
 the surface of a mirror or detector) is in the y-z plane. The center is at the origin of the
 coordiante system and the default size in each dimenstion is 1, measured from the center.
 Thus, e.g. the default definition for a `marxs.optics.detector.FlatDetector`, makes a detector surface with
-the following corners (in 3-d x,y,z coordinates): [0, -1, -1], [0, -1, 1], [0, 1, 1] and [0, 1, -1].
-This detector has the thickness 2 (from x=-1 to x=+1), but that only matters for display purposes, since the ray-trace
+the following corners (in 3-d x,y,z coordinates): [0, -1, -1], [0, -1, 1], [0,
+1, 1] and [0, 1, -1].
+Note that in a 3D visualization (see :ref:`visualization`), some elements might be shown with a thickness
+2 (from :math:`x=-1` to :math:`x=+1`), so that the "active surface" is in the middle of a box,
+while others might show the "active surface" as the edge of the box as in the
+sketch below. Details depend on the capabilities of the plotting backend
+(backends and options are listed in :ref:`sect-vis-api`).
+
+However, when running the ray-trace the code
 calculates the intersection with the "active surface" in the y-z plane independent of the
 thickeness in x-direction. There are exceptions to these defaults, those are noted in the description
 of the individual optical elements.

--- a/marxs/optics/detector.py
+++ b/marxs/optics/detector.py
@@ -43,7 +43,8 @@ class FlatDetector(FlatOpticalElement):
     '''name for output columns that contain this pixel number.'''
 
     display = {'color': (1.0, 1.0, 0.),
-               'shape': 'box'}
+               'shape': 'box',
+               'box-half': '+x'}
 
     def __init__(self, pixsize=1, **kwargs):
         self.pixsize = pixsize

--- a/marxs/optics/multiLayerMirror.py
+++ b/marxs/optics/multiLayerMirror.py
@@ -22,7 +22,8 @@ class FlatBrewsterMirror(FlatOpticalElement):
     probability of the reflected photons is adjusted to account for this overall loss.
     '''
     display = {'color': (0., 1., 0.),
-               'shape': 'box'
+               'shape': 'box',
+               'box-half': '+x',
     }
 
     def fresnel(self, photons, intersect, intersection, local):

--- a/marxs/visualization/mayavi.py
+++ b/marxs/visualization/mayavi.py
@@ -80,13 +80,37 @@ def surface(surface, display, viewer=None):
 
 @format_doc(doc_plot)
 def box(obj, display, viewer=None):
-    '''Plot a rectangular box for an object.'''
+    '''Plot a rectangular box for an object.
+
+    By default, the box extends in x,y, and z direction. The display keyword
+    "box-half" can be used to show only one half of the box, e.g. "+x" would
+    show  the full extend in y and z direction, but only the lower half in
+    x direction (such that rays coming from the +x direction are
+    visible up to the interaction point).
+    Use this for elements such as mirrors or detectors where
+    photon interaction happens on the surface, not in the substrate.
+    '''
     from mayavi import mlab
 
     corners = np.array([[-1, -1, -1], [-1,+1, -1],
                         [-1, -1,  1], [-1, 1,  1],
                         [ 1, -1, -1], [ 1, 1, -1],
                         [ 1, -1, +1], [ 1, 1, +1]])
+    if 'box-half' in display:
+        # write in a way that it works with any value for that keyword
+        try:
+            if display['box-half'][0] == '+':
+                factor = +1
+            elif display['box-half'][0] == '-':
+                factor = -1
+            else:
+                factor = 0
+            xyz = {'x': 0, 'y': 1, 'z': 2}
+            if display['box-half'][1] in xyz:
+                j = xyz[display['box-half'][1]]
+                corners[corners[:, j] == factor, j] = 0
+        except:
+            pass
     triangles = [(0,2,6), (0,4,6), (0,1,5), (0,4,5), (0,1,3), (0,2,3),
                  (7,3,2), (7,6,2), (7,3,1), (7,5,1), (7,6,4), (7,5,4)]
     corners = np.einsum('ij,...j->...i', obj.pos4d, mutils.e2h(corners, 1))
@@ -96,7 +120,13 @@ def box(obj, display, viewer=None):
 
 @format_doc(doc_plot)
 def cylinder(obj, display, viewer=None):
-    '''Plot a rectangular box for an object.'''
+    '''Plot a cylinder for an object.
+
+    The radius is taken from the y dimensions, the length of the tube from
+    the x dimension.
+    The display keyword "tube-sides" (default: 20) sets the number of vortices
+    that are used to approximate the curve.
+    '''
     from mayavi import mlab
 
     x0 = obj.geometry('center') - obj.geometry('v_x')


### PR DESCRIPTION
Before this change, the active surface of e.g. detector was in the center of a box, so even perfectly focussed rays would be seen as entering the detector in different places and they would then converge in the (invisible) center of the detector. This PR changes the 3d visualization to plot only half the detector (and some other optical elements) box, so that the active surface is not on the outside.