### PR TITLE
Improve plotting for Circle Apertures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@ New Features
 - Refactor `marxs.analysis.analysis.find_best_detector_position` to allow
   for more general objective functions. [#171]
 
+- Update plotting for `marxs.optics.aperture.CircleAperture` to give more 
+  flexibility in plotting the inner part of a ring-like aperture. This is
+  needed for models or stacked, rind-like apertures. [#180]
+
 API Changes
 ^^^^^^^^^^^
 

--- a/marxs/visualization/tests/test_utils.py
+++ b/marxs/visualization/tests/test_utils.py
@@ -2,7 +2,8 @@
 import numpy as np
 import pytest
 
-from ..utils import (plane_with_hole, get_color, color_tuple_to_hex,
+from ..utils import (plane_with_hole, combine_disjoint_triangulations,
+                     get_color, color_tuple_to_hex,
                      MARXSVisualizationWarning)
 from ..mayavi import plot_object
 
@@ -28,6 +29,19 @@ def test_hole_round():
         assert set(tri[:, 1]) == set(np.arange(4 + n))
         # Check last point is always on inner rim
         assert set(tri[:, 2]) == set(np.arange(4, 4 + n))
+
+def test_stack_triangulations():
+    xyz = np.array([[-1. , -1. ,  0. ],
+                    [-1. ,  1. ,  0. ],
+                    [ 1. ,  1. ,  0. ],
+                    [ 1. , -1. ,  0. ]])
+    triangles = np.array([[0, 1, 2], [0, 2, 3]])
+    xyz_out, tri_out = combine_disjoint_triangulations([xyz, xyz + 5.3],
+                                                       [triangles, triangles])
+    assert np.all(xyz_out[:4, :] == xyz)
+    assert np.allclose(xyz_out[4:, :], xyz + 5.3)
+    assert np.all(tri_out[:2, :] == triangles)
+    assert np.all(tri_out[2:, :] == triangles + 4)
 
 def test_color_roundtrip():
     '''Test that the different color convertes are consistent.'''

--- a/marxs/visualization/utils.py
+++ b/marxs/visualization/utils.py
@@ -209,3 +209,33 @@ def plane_with_hole(outer, inner):
             triangles[i, :] = [i_out, (i_out + 1) % n_out, n_out + (i_in % n_in)]
             i_out = (i_out + 1) % n_out
     return xyz, triangles
+
+
+def combine_disjoint_triangulations(list_xyz, list_triangles):
+    '''Combine two disjoint triangulations into one set of points
+
+    This function combines two entirely separate triangulations into one set
+    of point and triangles. Plotting the combined triangulation should have the
+    same effect as plotting each triangulation separately. This function is used
+    for plotting apertures where we have e.g. an open ring. This can be plotted
+    as an inner circle plus an outer shape with a hole in it.
+
+    Parameters
+    ----------
+    list_xyz : list of `np.array`
+        Each array holds xyz values for one triangulation
+    list_triangles : list of nd.array
+        Each array holds the list of the indices for one triangulation.
+
+    Returns
+    -------
+    xyz : nd.array
+        stacked ``outer`` and ``inner``.
+    triangles : nd.array
+        List of the indices. Each row has the index of three points in ``xyz``.
+    '''
+    xyz = np.vstack(list_xyz)
+    n_offset = np.cumsum([a.shape[0] for a in list_xyz])
+    n_offset -= n_offset[0]
+    triangles = np.vstack([list_triangles[i] + n_offset[i] for i in range(len(n_offset))])
+    return xyz, triangles


### PR DESCRIPTION
Update plotting for `marxs.optics.aperture.CircleAperture` to give more
  flexibility in plotting the inner part of a ring-like aperture. This is
  needed for models or stacked, rind-like apertures.