### PR TITLE
Remove tests comparing the MARX C code to the Python version of HRMA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,10 +87,10 @@ matrix:
         # Try Astropy development version
         - python: 3.6
           env: ASTROPY_VERSION=development
-	# The LTS version uses legacy numpy formatting for table column
-	# and that makes one of the doctests fail.
-	# The next LTS is not far, so I stop supporting the old one for now
-	# although it probably still works.
+        # The LTS version uses legacy numpy formatting for table column
+        # and that makes one of the doctests fail.
+        # The next LTS is not far, so I stop supporting the old one for now
+        # although it probably still works.
         #- python: 3.6
         #  env: ASTROPY_VERSION=lts
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,16 +37,16 @@ env:
 
 
 before_install:
-  - wget ftp://space.mit.edu/pub/cxc/marx/v5.1/marx-dist-5.1.0.tar.gz
-  - tar -xvf marx-dist-5.1.0.tar.gz
+  - wget ftp://space.mit.edu/pub/cxc/marx/v5.3/marx-dist-5.3.3.tar.gz
+  - tar -xvf marx-dist-5.3.3.tar.gz
   - pwd
-  - cd marx-5.1.0 && ./configure --prefix=$TRAVIS_BUILD_DIR/marx/ CFLAGS="-O2 -g -fPIC" && make && make install
+  - cd marx-5.3.3 && ./configure --prefix=$TRAVIS_BUILD_DIR/marx/ CFLAGS="-O2 -g -fPIC" && make && make install
   - cd ..
 
 install:
 
     # Set the location the MARX c code and compiled version in setup.cfg
-    - sed -i.bak 's|srcdir =|srcdir = '"$(echo $TRAVIS_BUILD_DIR)"'/marx-5.1.0/|g' setup.cfg
+    - sed -i.bak 's|srcdir =|srcdir = '"$(echo $TRAVIS_BUILD_DIR)"'/marx-5.3.3/|g' setup.cfg
     - sed -i.bak 's|libdir =|libdir = '"$(echo $TRAVIS_BUILD_DIR)"'/marx/lib/|g' setup.cfg
 
     # We now use the ci-helpers package to set up our testing environment.

--- a/marxs/missions/chandra/tests/test_hrma.py
+++ b/marxs/missions/chandra/tests/test_hrma.py
@@ -12,11 +12,6 @@ aperpy = Aperture()
 mirrpy = HRMA()
 
 
-def test_area():
-    '''Compare aperture area to MARX C code'''
-    assert np.isclose(marx.area, aperpy.area, rtol=0.01, atol=1e-8 * u.mm**2)
-
-
 def test_FWHM():
     '''Compare properties of PSF to MARX C code'''
     coords = SkyCoord(25., 45., unit=u.deg)
@@ -35,7 +30,6 @@ def test_FWHM():
     assert np.isclose(np.nanstd(pmarx['det_x']), np.nanstd(ppy['det_x']), rtol=0.25)
     assert np.isclose(np.nanstd(pmarx['det_y']), np.nanstd(ppy['det_y']), rtol=0.25)
     assert np.isclose(np.nanmean(ppy['det_x']), 0, atol=1e-3)
-    assert np.isclose(ppy['probability'].sum(), pmarx['probability'].sum(), rtol=0.1)
 
 
 def test_most_photons_hit_grating():


### PR DESCRIPTION
Due to Chandra-MARX/marx/#21 the C implementation and the Python
implementation of the aperture are not longer directly comparable.
For the simple version of a perfect thin lens in Python the aperture
sits right on top of the mirror plane and this the issue in
Chandra-MARX/marx/#21 is not relevant here.
As a consequence, aperture sizes and photon probabilities are no
longer directly comparable and those tests need to be removed.