### PR TITLE
Remove Python 2 compatibility

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,6 +7,7 @@ Requirements
 
 MARXS has few hard requirements:
 
+- MARXS requires Python version > 3.6.
 - `numpy <http://www.numpy.org/>`_
 - `astropy`_
 - `transforms3d <https://matthew-brett.github.io/transforms3d/>`_
@@ -17,12 +18,15 @@ Numpy and astropy are best installed with a package manager such as conda. See t
 
 The following Python packages are strongly recommended, but most parts of MARXS will work without them:
 
-- scipy
+- `scipy <http://www.numpy.org/>`_
 - matplotlib
-- mayavi (for 3 D output)
+- `mayavi <https://docs.enthought.com/mayavi/mayavi/>`_ (for 3 D output)
 - jsonschema
 
-Again, these are all available through common package managers such as conda, ``apt-get`` etc.
+Again, all but mayavi are available through common package managers such as
+conda, ``apt-get`` etc. For `mayavi
+<https://docs.enthought.com/mayavi/mayavi/>`_ see `the mayavi installation
+instructions <https://docs.enthought.com/mayavi/mayavi/installation.html#installing-with-pip>`_.
   
 In addition MARXS has an interface to the `classic marx`_ C code used to simulate the Chandra mirrors (:ref:`sect-installmarxccode`).
   

--- a/marxs/base/base.py
+++ b/marxs/base/base.py
@@ -6,9 +6,7 @@ from copy import deepcopy
 
 import numpy as np
 from transforms3d import affines
-
 from astropy.table import Column
-from astropy.extern.six import with_metaclass
 
 from ..visualization.utils import DisplayDict
 
@@ -54,7 +52,7 @@ class DocMeta(type):
         return type.__new__(mcs, name, bases, dict)
 
 
-class MarxsElement(with_metaclass(DocMeta, object)):
+class MarxsElement(metaclass=DocMeta):
     '''Base class for all elements in a MARXS simulation.
 
     This includes elements that actually change photon properties such as grating and

--- a/marxs/optics/marx.py
+++ b/marxs/optics/marx.py
@@ -6,7 +6,6 @@
 import os
 import numpy as np
 from astropy.table import Table, Column, join
-from astropy.extern import six
 import astropy.units as u
 
 from ..math.utils import h2e, e2h
@@ -71,10 +70,7 @@ class MarxMirror(OpticalElement, BaseAperture):
             raise IOError('MARX parameter file {0} does NOT exist.'.format(parfile))
         else:
             self.parfile = parfile
-        if six.PY2:
-            self.cparfile = marx.pf_open_parameter_file(parfile, 'r')
-        else:
-            self.cparfile = marx.pf_open_parameter_file(bytes(parfile, 'utf8'), bytes('r', 'utf8'))
+        self.cparfile = marx.pf_open_parameter_file(bytes(parfile, 'utf8'), bytes('r', 'utf8'))
         out = marx.marx_mirror_init(self.cparfile)
         if out < 0:
             raise MarxError('Mirror cannot be initialized. Probably missing parameters or syntax error in {0}.'.format(parfile))

--- a/marxs/optics/marx_build.py
+++ b/marxs/optics/marx_build.py
@@ -1,6 +1,6 @@
 # Licensed under GPL version 3 - see LICENSE.rst
 from os import path
-from astropy.extern.six.moves.configparser import ConfigParser
+from configparser import ConfigParser
 from cffi import FFI
 
 with open ("marxs/optics/cdef.txt", "r") as myfile:

--- a/marxs/simulator/simulator.py
+++ b/marxs/simulator/simulator.py
@@ -97,7 +97,7 @@ class Sequence(BaseContainer):
 
     Now, let us check where the photons fall on the detector:
 
-    >>> set(photons_out['detpix_x'].round())  # doctest: +IGNORE_OUTPUT
+    >>> set(photons_out['detpix_x'].round())
     {19.0, 20.0}
 
     As expected, they fall right around the center of the detector (row 19 and 20 of a

--- a/marxs/tests/test_base.py
+++ b/marxs/tests/test_base.py
@@ -1,9 +1,8 @@
 # Licensed under GPL version 3 - see LICENSE.rst
 from ..base import DocMeta
-from astropy.extern.six import with_metaclass
 
 def test_docsting_inheritance():
-    class A(with_metaclass(DocMeta, object)):
+    class A(metaclass=DocMeta):
         '''class doc here'''
 
         A = 5 # int: attribute A


### PR DESCRIPTION
This is just a start removing six and related imports since all the old syntax
(e.g. super with arguments) is still valid, but from this commit on, now code will
be developed in Python 3 syntax.

closes #65