### PR TITLE
Bug fix: Multiaperture sorted photons by aperture number

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,10 @@ Bug fixes
 - Plot only "half-box" for elements such as mirrors where the optical
   interaction occurs on a surface. [#178]
 
+- With `marxs.optics.MultiAperture` photons would always be sorted by aperture
+  number. To fix this, apertures now behave more like other optical elements
+  and use ``process_photons``. [#189]
+
   
   
 Other changes and additions

--- a/marxs/base/base.py
+++ b/marxs/base/base.py
@@ -18,12 +18,12 @@ class DocMeta(type):
     '''Metaclass to inherit docstrings when reqired.
 
     When a derived class overwrites a method that was already defined in its
-    base class, the new method usually has the same purpose as the original method
-    and often uses the same parameters, too, although the implementation differs
-    slightly.
-    In this case, it should have the same docstring, too.
-    This metaclass will look for methods that are undocumented and add the docstring
-    of the appropriate parent method to them.
+    base class, the new method usually has the same purpose as the original
+    method and often uses the same parameters, too, although the implementation
+    differs slightly.  In this case, it should have the same docstring, too.
+    This metaclass will look for methods that are undocumented and add the
+    docstring of the appropriate parent method to them.
+
     '''
     def __new__(mcs, name, bases, dict):
         # make a class here with the same method resolution order
@@ -94,30 +94,31 @@ class SimulationSequenceElement(MarxsElement):
         dir : `numpy.ndarray`
             4-d direction vector of ray in homogeneous coordinates
         pos : `numpy.ndarray`
-            4-d position of last interaction pf the photons with any optical element in
-            homogeneous coordinates. Together with ``dir`` this determines the equation
-            of the ray.
+            4-d position of last interaction pf the photons with any optical
+            element in homogeneous coordinates. Together with ``dir`` this
+            determines the equation of the ray.
         energy : float
             Photon energy in keV.
         polarization : float
             Polarization angle of the photons.
         probability : float
-            Probability that the photon continues. Set to 0 if the photon is absorbed, to 1 if it
-            passes the optical element and to number between 0 and 1 to express a probability that
-            the photons passes.
+            Probability that the photon continues. Set to 0 if the photon is
+            absorbed, to 1 if it passes the optical element and to number
+            between 0 and 1 to express a probability that the photons passes.
     '''
 
     id_col = None
     '''String that names an id column for output.
 
-    Set this to a string to add an automatic numbering to the output. This is especially useful
-    if there are several identical optical components that are used in parallel, e.g. there
-    are four identical CCDs. Setting ``id_col = "CCD_ID"`` and passing an ``id_num=1, 2, 3, 4``
-    keyword respectively to each CCD
-    will add a column ``CCD_ID`` with a value of 1,2,3, or 4 for each photon hitting one of those
-    CCDs.
+    Set this to a string to add an automatic numbering to the output. This is
+    especially useful if there are several identical optical components that
+    are used in parallel, e.g. there are four identical CCDs. Setting ``id_col
+    = "CCD_ID"`` and passing an ``id_num=1, 2, 3, 4`` keyword respectively to
+    each CCD will add a column ``CCD_ID`` with a value of 1,2,3, or 4 for each
+    photon hitting one of those CCDs.
 
     Currently, this will not work with all optical elements.
+
     '''
 
     def __init__(self, **kwargs):
@@ -130,7 +131,8 @@ class SimulationSequenceElement(MarxsElement):
     def add_output_cols(self, photons, colnames=[]):
         '''Add output columns of the correct format (currently: float) to the photon array.
 
-        This function takes the column names that are added to ``photons`` from several sources:
+        This function takes the column names that are added to ``photons`` from
+        several sources:
 
         - `id_col` (if not ``None``)
         - `output_columns`
@@ -141,8 +143,8 @@ class SimulationSequenceElement(MarxsElement):
         photons : `astropy.table.Table`
             Table columns are added to.
         colnames : list of strings
-            Column names to be added; in addition several object properties can be used to
-            set the column names, see description above.
+            Column names to be added; in addition several object properties can
+            be used to set the column names, see description above.
         '''
         temp = np.empty(len(photons))
         temp[:] = np.nan

--- a/marxs/optics/aperture.py
+++ b/marxs/optics/aperture.py
@@ -2,7 +2,6 @@
 import numpy as np
 from astropy import table
 import astropy.units as u
-from astropy.utils.metadata import enable_merge_strategies
 
 from .base import FlatOpticalElement
 from ..base import GeometryError
@@ -21,10 +20,12 @@ class BaseAperture(object):
     @staticmethod
     def add_colpos(photons):
         '''add columns ['pos'] to photon array'''
-        photoncoords = table.Column(name='pos', length=len(photons), shape=(4,))
-        photons.add_column(photoncoords)
-        photons['pos'][:, 3] = 1
-        photons['pos'].unit = u.mm
+        if 'pos' not in photons.colnames:
+            photoncoords = table.Column(name='pos', length=len(photons),
+                                        shape=(4,))
+            photons.add_column(photoncoords)
+            photons['pos'][:, 3] = 1
+            photons['pos'].unit = u.mm
 
     @property
     def area(self):
@@ -38,6 +39,18 @@ class BaseAperture(object):
 
 class FlatAperture(BaseAperture, FlatOpticalElement):
     'Base class for geometrically flat apertures defined in python'
+
+    def __call__(self, photons):
+        # The last two arguments make no sense for apertures - the
+        # intercoos and interpoos are assigned in specific_process_photons
+        # instead of derived from intersect - but we need something here
+        # to keep the interface the same as in FlatOpticalElement.
+        self.add_colpos(photons)
+        self.process_photons(photons, np.ones(len(photons), dtype=bool),
+                             photons['pos'],
+                             np.zeros((len(photons), 2)))
+        return photons
+
     def generate_local_xy(self, n):
         '''Generate x, y in the local coordinate system
 
@@ -53,26 +66,17 @@ class FlatAperture(BaseAperture, FlatOpticalElement):
         '''
         return NotImplementedError
 
-    def __call__(self, photons):
-        self.add_output_cols(photons, self.geometry.loc_coos_name)
-        # Add ID number to ID col, if requested
-        if self.id_col is not None:
-            photons[self.id_col] = self.id_num
-        # Set position in different coordinate systems
-        x, y = self.generate_local_xy(len(photons))
-        if self.geometry.loc_coos_name is not None:
-            photons[self.geometry.loc_coos_name[0]][:] = x
-            photons[self.geometry.loc_coos_name[1]][:] = y
-        photons['pos'] = self.geometry['center'] + x.reshape((-1, 1)) * self.geometry['v_y'] + y.reshape((-1, 1)) * self.geometry['v_z']
-        projected_area = np.dot(photons['dir'].data, - self.geometry['e_x'])
-        # Photons coming in "through the back" would have negative probabilities.
+    def specific_process_photons(self, photons, intersect, interpos, intercoos):
+        x, y = self.generate_local_xy(intersect.sum())
+
+        intercoos[intersect, 0] = x
+        intercoos[intersect, 1] = y
+        interpos[intersect, :] = self.geometry['center'] + x.reshape((-1, 1)) * self.geometry['v_y'] + y.reshape((-1, 1)) * self.geometry['v_z']
+        projected_area = np.dot(photons['dir'][intersect].data,
+                                - self.geometry['e_x'])
+        # Photons coming "through the back" would have negative probabilities.
         # Unlikely to ever come up, but just in case we clip to 0.
-        photons['probability'][:] *= np.clip(projected_area, 0, 1.)
-
-        return photons
-
-    def process_photons(self, photons):
-        raise NotImplementedError('You probably want to use __call__.')
+        return {'probability': np.clip(projected_area, 0, 1.)}
 
     def outer_shape(self):
         '''Return values in Eukledian space.'''
@@ -99,9 +103,9 @@ class RectangleAperture(FlatAperture):
 class CircleAperture(FlatAperture):
     '''Select the position where a parallel ray from an astrophysical source starts the simulation.
 
-    Photons are placed in a circle. The radius of the circle is the lengths of its ``v_y`` vector.
-    At this point, the aperture must have the same zoom in y and z direction; it cannot be used
-    to simulate an entrance ellipse.
+    Photons are placed in a circle. The radius of the circle is the lengths of
+    its ``v_y`` vector.  At this point, the aperture must have the same zoom in
+    y and z direction; it cannot be used to simulate an entrance ellipse.
 
     Parameters
     ----------
@@ -113,10 +117,12 @@ class CircleAperture(FlatAperture):
         the y axis. (Default is the full circle.)
     r_inner : float
         Inner radius for ring-like apertures. Default is 0 (full circle). If
-        `r_inner` is non-zero, plotting the aperture will fill in the inner region.
-        If this is not desired because several `CircleApertures` are stacked into each other,
-        ``self.display['inner_factor']`` can be used to restrict the radius range where the
-        inner disk is displayed in a plot.
+        `r_inner` is non-zero, plotting the aperture will fill in the inner
+        region.  If this is not desired because several `CircleApertures` are
+        stacked into each other, ``self.display['inner_factor']`` can be used
+        to restrict the radius range where the inner disk is displayed in a
+        plot.
+
     '''
 
     default_geometry = CircularHole
@@ -150,16 +156,16 @@ class CircleAperture(FlatAperture):
 class MultiAperture(BaseAperture, BaseContainer):
     '''Group several apertures into one class.
 
-    Sometimes a single intrument has several physical openings where photons from an
-    astrophysical source can enter, an example is XMM-Newton that operates three telescopes
-    in parallel. While it is often more efficient to simulate these as entirely separate by
-    running separate simulations, that is not always true.
-    This class groups several apertures together.
+    Sometimes a single intrument has several physical openings where photons
+    from an astrophysical source can enter, an example is XMM-Newton that
+    operates three telescopes in parallel. While it is often more efficient to
+    simulate these as entirely separate by running separate simulations, that
+    is not always true. This class groups several apertures together.
 
     .. warning::
 
-       Apertures cannot overlap. There is currently no code checking for this, but
-       overlapping apertures will produce unphysical results.
+       Apertures cannot overlap. There is currently no code checking for this,
+       but overlapping apertures will produce unphysical results.
 
 
     Parameters
@@ -167,19 +173,26 @@ class MultiAperture(BaseAperture, BaseContainer):
     elements : list
         The elements of this list are all optical elements that process photons.
     preprocess_steps : list
-        The elements of this list are functions or callable objects that accept a photon list as input
-        and return no output (*default*: ``[]``). All ``preprocess_steps`` are run before
-        *every* aperture on just the photons that pass this aperture.
+        The elements of this list are functions or callable objects that accept
+        a photon list as input and return no output (*default*: ``[]``). All
+        ``preprocess_steps`` are run before *every* aperture on just the
+        photons that pass this aperture.
     postprocess_steps : list
-        See ``preprocess_steps`` except that the steps are run *after* each aperture
-         (*default*: ``[]``) on just the photons that passed that aperture.
+        See ``preprocess_steps`` except that the steps are run *after* each
+        aperture (*default*: ``[]``) on just the photons that passed that
+        aperture.
+
     '''
     display = {'shape': 'container'}
 
     def __init__(self, **kwargs):
         self.elements = kwargs.pop('elements')
         self.id_col = kwargs.pop('id_col', 'aperture')
+        self.id_num_offset = kwargs.pop('id_num_offset', 0)
         super(MultiAperture, self).__init__(**kwargs)
+        for i, elem in enumerate(self.elements):
+            elem.id_col = self.id_col
+            elem.id_num = self.id_num_offset + i
 
     @property
     def area(self):
@@ -187,22 +200,20 @@ class MultiAperture(BaseAperture, BaseContainer):
         return u.Quantity([e.area for e in self.elements]).sum()
 
     def __call__(self, photons):
+        self.add_colpos(photons)
         areas = u.Quantity([e.area for e in self.elements])
         aperid = np.digitize(np.random.rand(len(photons)), np.cumsum(areas) / self.area)
+        np.random.shuffle(aperid)
 
-        # Add ID number to ID col, if requested
-        if self.id_col is not None:
-            photons[self.id_col] = aperid
-        outs = []
         for i, elem in enumerate(self.elements):
-            thisphot = photons[aperid == i]
             for p in self.preprocess_steps:
-                p(thisphot)
-            thisphot = elem(thisphot)
+                p(photons)
+            # The following line differs from "normal" optical
+            # elements. In other elements "intersect" decides
+            # which photons are touched, here we pass that in.
+            photons = elem.process_photons(photons, aperid==i,
+                                           photons['pos'],
+                                           np.zeros((len(photons), 2)))
             for p in self.postprocess_steps:
-                p(thisphot)
-            outs.append(thisphot)
-        with enable_merge_strategies(utils.MergeIdentical):
-            photons = table.vstack(outs)
-
+                p(photons)
         return photons

--- a/marxs/optics/tests/test_all_optics.py
+++ b/marxs/optics/tests/test_all_optics.py
@@ -20,7 +20,8 @@ from .. import (RectangleAperture, ThinLens, FlatDetector, CircularDetector,
 
 from ..aperture import BaseAperture
 from ...source import PointSource, FixedPointing
-from ..base import _parse_position_keywords, FlatStack
+from ..base import FlatStack
+from ...base import _parse_position_keywords
 from ...design import (RowlandTorus, GratingArrayStructure,
                        LinearCCDArray, RowlandCircleArray,
                        RectangularGrid)

--- a/marxs/optics/tests/test_apertures.py
+++ b/marxs/optics/tests/test_apertures.py
@@ -81,6 +81,11 @@ def test_MultiAperture():
     assert (p['aper'] == 0).sum() + (p['aper'] == 1).sum() == 1000
     # Most photons go through the bigger aperture
     assert (p['pos'][1:] > 1).sum() > 650
+    # Regression: Check apertures are not sorted in time [#189]
+    ind1 = (p['aper'] == 0).nonzero()[0]
+    ind2 = (p['aper'] == 1).nonzero()[0]
+    assert not np.max(ind1) <  np.min(ind2)
+    assert not np.min(ind1) > np.max(ind2)
 
 def test_geomarea_projection():
     '''When a ray sees the aperture under an angle the projected aperture size


### PR DESCRIPTION
To fix this, apertures now behave more like other optical elements and make use of
the process_photons and specific_process_photons machinary.
This also avoids a table splitting and merging which before caused a performance
penalty for a large number of small apertures (e.g. one aperture per SPO in Arcus).