### PR TITLE
Remove merge strategy "MergeIdentical"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,9 @@ API Changes
   ``detector.geometry['center']`` instead of a function interface with
   ``(...)``. [#182]
 
+- Remove ``utils.MergeIdentical`` merge strategy since it is not longer used
+  after #189. [#191]
+
 
 
 

--- a/marxs/utils.py
+++ b/marxs/utils.py
@@ -1,9 +1,8 @@
 import numpy as np
 from astropy.table import Table
-from astropy.utils.metadata import MergeStrategy
 import warnings
 
-__all__ = ['SimulationSetupWarning', 'generate_test_photons', 'MergeIdentical']
+__all__ = ['SimulationSetupWarning', 'generate_test_photons']
 
 
 class SimulationSetupWarning(Warning):
@@ -45,22 +44,3 @@ def generate_test_photons(n=1):
                      'probability': np.ones(n),
                      })
     return photons
-
-
-class MergeIdentical(MergeStrategy):
-    '''Merge metadata in astropy table
-
-    In some cases, a table of photons is split up, e.g. when half of
-    the photons passes through one aperture and the other half through
-    a second aperture. When merging those tables back together, they
-    have the same metadata, but the default `astropy.utils.metadata.MergePlus`
-    would lead to doubled entries.
-    '''
-    types = [(list, list), (tuple, tuple)]
-
-    @classmethod
-    def merge(cls, left, right):
-        if left == right:
-            return left
-        else:
-            return left + right


### PR DESCRIPTION
Since #189, this is no longer used, because apertures don't split and
merge tables any longer.

closes #190