### PR TITLE
The column names for blaze and order written by

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@ New Features
 
 - Add class `marxs.optics.scatter.RandomGaussianScatter`. [#192]
 
+- The column names for blaze and order written by
+  `marxs.optics.gratings.FlatGrating` can now be configured. [#195]
+
+
 API Changes
 ^^^^^^^^^^^
 - The geometry of a class is now defined as a separate object from the new

--- a/marxs/optics/grating.py
+++ b/marxs/optics/grating.py
@@ -132,6 +132,12 @@ class FlatGrating(FlatOpticalElement):
     loc_coos_name = ['grat_y', 'grat_z']
     '''name for output columns that contain the interaction point in local coordinates.'''
 
+    order_name = 'order'
+    '''Column name for diffraction order. If set to ``None`` this is not added to the photon list.'''
+
+    blaze_name = 'blaze'
+    '''Column name for blaze angle. If set to ``None`` this is not added to the photon list.'''
+
     def order_sign_convention(self, p, e_perp_groove):
         '''Set sign convention for grating orders.
 
@@ -256,8 +262,13 @@ class FlatGrating(FlatOpticalElement):
         dir, m, p, blaze = self.diffract_photons(photons, intersect, interpos, intercoos)
         pol = parallel_transport(photons['dir'].data[intersect, :], dir,
                                  photons['polarization'].data[intersect, :])
-        return {'dir': dir, 'probability': p, 'order': m, 'blaze': blaze,
-                'polarization': pol}
+        out = {'dir': dir, 'probability': p, 'polarization': pol}
+        if self.order_name is not None:
+            out[self.order_name] = m
+        if self.blaze_name is not None:
+            out[self.blaze_name] = blaze
+        return out
+
 
 class CATGrating(FlatGrating):
     '''Critical-Angle-Transmission Grating

--- a/marxs/optics/tests/test_grating.py
+++ b/marxs/optics/tests/test_grating.py
@@ -317,6 +317,7 @@ def test_change_position_after_init():
     photons = generate_test_photons(5)
 
     g1 = FlatGrating(d=1./500, order_selector=OrderSelector([1]), groove_angle=.3)
+    g1.order_name = 'one'
     p1 = g1(photons.copy())
 
     pos3d = axangles.axangle2mat([1,0,0], .3)
@@ -325,10 +326,16 @@ def test_change_position_after_init():
     g2 = FlatGrating(d=1./500, order_selector=OrderSelector([1]), position=trans)
     # then move it so that pos and groove direction match g1
     g2.geometry.pos4d = affines.compose(np.zeros(3), pos3d, 25.*np.ones(3))
+    g2.blaze_name = 'myblaze'
     p2 = g2(photons.copy())
 
     assert np.allclose(p1['dir'], p2['dir'])
     assert np.allclose(p1['pos'], p2['pos'])
+
+    # Check naming of the grating output columns
+    assert np.all(p1['one'] == 1)
+    assert 'myblaze' in p2.colnames
+
 
 def test_gratings_are_independent():
     '''Regression test: Some grating properties are stored in a dict.


### PR DESCRIPTION
  `marxs.optics.gratings.FlatGrating` can now be configured.