### PR TITLE
`run_tolerances` modifies the inpout parameters

### DIFF
--- a/marxs/design/tests/test_tolerancing.py
+++ b/marxs/design/tests/test_tolerancing.py
@@ -52,7 +52,7 @@ def test_change_parallel_elements(function):
     '''Check that parameters work and elements are in fact changed.
     More detailed checks that the type of change is correct are
     implemented as separate tests, but those tests don't check out
-    every parameter/
+    every parameter.
     '''
     g = gsa()
     function(g, 0., 0., 0.)
@@ -183,7 +183,10 @@ def test_runtolerances():
     assert out[1]['meanorder'] == 1
     # check parameters are in output
     assert out[1]['orderlist'] == [1, 2]
-
+    # check original parameters is still intact and can be used again
+    # Regression test: If results are inserted into the same dict
+    # 'meanorder' will appear with is not valid for varyorderselector
+    assert 'meanorder' not in parameters[0]
 
 def test_capture_res_aeff():
     '''Test the captures res/aeff class.

--- a/marxs/design/tolerancing.py
+++ b/marxs/design/tolerancing.py
@@ -1,6 +1,7 @@
 import inspect
 from functools import wraps
 import collections
+from copy import copy
 
 import numpy as np
 from transforms3d import affines, euler
@@ -223,8 +224,9 @@ def run_tolerances(photons_in, instrum, wigglefunc, wiggleparts,
         print(f'Working on simulation {i}/{len(parameters)}')
         wigglefunc(wiggleparts, **pars)
         photons = instrum(photons_in.copy())
-        pars.update(analyzefunc(photons))
-        out.append(pars)
+        cpars = copy(pars)
+        cpars.update(analyzefunc(photons))
+        out.append(cpars)
 
     return out
 

--- a/marxs/math/geometry.py
+++ b/marxs/math/geometry.py
@@ -365,7 +365,7 @@ class Cylinder(Geometry):
     '''A Geometry shaped like a ring or tube.
 
     This object is shaped like a tube. The form is a circle in the xy plane
-    and and flat along the z-direction.  This can be used, for example to
+    and flat along the z-direction.  This can be used, for example to
     simulate a setup that can follow the Rowland circle
     geometry exactly which is useful, e.g. to study the resolution of a
     spectrograph without worrying about the details of the detector geometry.

--- a/marxs/optics/base.py
+++ b/marxs/optics/base.py
@@ -28,7 +28,7 @@ class OpticalElement(SimulationSequenceElement):
     '''
 
     default_geometry = FinitePlane
-    '''If not geometry is passed in on initialization, an instance of this class will be used.'''
+    '''If no geometry is specified on initialization, an instance of this class will be used.'''
 
     # SimulationSequenceElement has display none, but now we have a geometry
     # so we don't need that default here.


### PR DESCRIPTION
The same tolerances could not be used twice, because the analysis output
was added to the input dictionary. Thus, wehn running it a second time,
error like
ValueError: Object <arcus.defaults.DefaultPointing object at 0x7ff7cad4a438> does not have Aeff0 attribute.
would appear, because the analsys function added an Aeff and other values.
Now, the input parameter dist is copied so that that changes don't effect the
input list.