### PR TITLE
Add second base class to FlatStack

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,7 +44,6 @@ API Changes
 
 
 
-
 Bug fixes
 ^^^^^^^^^
 
@@ -71,7 +70,9 @@ Bug fixes
   number. To fix this, apertures now behave more like other optical elements
   and use ``process_photons``. [#189]
 
-  
+- `marxs.optics.FlatStack` now inherits from `marxs.simulator.BaseContainer`.
+  [#196]
+
   
 Other changes and additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/marxs/optics/base.py
+++ b/marxs/optics/base.py
@@ -6,6 +6,7 @@ from astropy.table import Table, Row
 
 from ..math.geometry import Geometry, FinitePlane
 from ..base import SimulationSequenceElement
+from ..simulator import BaseContainer
 
 class OpticalElement(SimulationSequenceElement):
     '''Base class for all optical elements in marxs.
@@ -172,7 +173,7 @@ class FlatOpticalElement(OpticalElement):
     pass
 
 
-class FlatStack(FlatOpticalElement):
+class FlatStack(FlatOpticalElement, BaseContainer):
     '''Convenience class for several flat, stacked optical elements.
 
     This class is meant to simplify the specification of a single physical


### PR DESCRIPTION
Without the `BaseContainer` base class, a flat Stack object can't be searched with `elements_of_class` or plotted in the same way that other containers are.