### PR TITLE
Make dimensions of L1 support configurable in MIT SNL gratings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,8 +115,9 @@ matrix:
         - os: linux
           env: ASTROPY_VERSION=development
                EVENT_TYPE='pull_request push cron'
-        - os: linux
-          env: PYTHON_VERSION=3.6 ASTROPY_VERSION=lts NUMPY_VERSION=1.13
+        # marxs does not support LTS any longer
+        #- os: linux
+        #  env: PYTHON_VERSION=3.6 ASTROPY_VERSION=lts NUMPY_VERSION=1.13
 
         # Add a job that runs from cron only and tests against astropy dev and
         # numpy dev to give a change for early discovery of issues and feedback

--- a/.travis.yml
+++ b/.travis.yml
@@ -145,8 +145,8 @@ matrix:
         # Do a PEP8 test with flake8
         # (do allow to fail unless your code completely compliant)
         - os: linux
-           stage: Initial tests
-           env: MAIN_CMD='flake8 marxs --count --show-source --statistics $FLAKE8_OPT' SETUP_CMD=''
+          stage: Initial tests
+          env: MAIN_CMD='flake8 marxs --count --show-source --statistics $FLAKE8_OPT' SETUP_CMD=''
 
 script:
    - python setup.py $SETUP_CMD

--- a/marxs/design/tolerancing.py
+++ b/marxs/design/tolerancing.py
@@ -136,6 +136,8 @@ def varyattribute(element, **kwargs):
     of those elements.
     '''
     for key, val in kwargs.items():
+        # check is needed because key could be misspelled so that we set an attribute
+        # that did not exist before and that is never used
         if not hasattr(element, key):
             raise ValueError(f'Object {element} does not have {key} attribute.')
         setattr(element, key, val)

--- a/marxs/missions/mitsnl/tests/test_cat.py
+++ b/marxs/missions/mitsnl/tests/test_cat.py
@@ -101,7 +101,7 @@ def test_efficiency_table_in_use():
     '''Use table in a optical element'''
     efftab = InterpolateEfficiencyTable(get_pkg_data_filename('grating_efficiency.csv'), k=2)
     cat = CATGrating(order_selector=efftab, d=0.001)
-    photons = generate_test_photons(500)
+    photons = generate_test_photons(5000)
     photons = cat(photons)
     assert np.isclose((photons['order']==0).sum(), len(photons) / 2, rtol=.05)
 

--- a/marxs/missions/mitsnl/tests/test_cat.py
+++ b/marxs/missions/mitsnl/tests/test_cat.py
@@ -6,7 +6,7 @@ from astropy.utils.data import get_pkg_data_filename
 from transforms3d.euler import euler2mat
 
 from ..catgrating import *
-from ..catgrating import DataFileFormatException
+from ..catgrating import DataFileFormatException, check_lx_dims
 from marxs.optics import CATGrating, OrderSelector, FlatDetector
 from marxs.optics.scatter import RandomGaussianScatter
 from marxs.utils import generate_test_photons
@@ -25,15 +25,21 @@ def test_nonparallelCATGrating_simplifies_to_CATGrating():
     p2 = npcat(photons)
     assert np.all(p1['dir'] == p2['dir'])
 
+def test_check():
+    '''Make sure check raises Exception for unphysical parameters'''
+    with pytest.raises(ValueError):
+        check_lx_dims({'barwidth': 1, 'period': 1})
 
 def test_scalingSitransparancy():
     '''The module has data for 1 mu Si and scales that to the depth of the
     grating. Test against known-good coefficient from CXRO.'''
-    photons = generate_test_photons(1)
-    cat = L1(order_selector=OrderSelector([-5]), relativearea=0.,
-             depth=4*u.mu, d=0.00001)
+    photons = generate_test_photons(100)
+    cat = L1(order_selector=OrderSelector([-5]),
+             l1_dims = {'bardepth': 0.004 * u.mm,
+                        'period': 0.0001 * u.mm,
+                        'barwidth': 0.00009 * u.mm})
     photons = cat(photons)
-    assert np.isclose(photons['probability'][0], 0.22458, rtol=1e-4)
+    assert np.isclose(np.median(photons['probability']), 0.22458, rtol=1e-4)
 
 
 def test_L2_broadening():

--- a/marxs/optics/tests/test_all_optics.py
+++ b/marxs/optics/tests/test_all_optics.py
@@ -85,7 +85,7 @@ all_oe = [ThinLens(focallength=100),
           # elements in MIT SNL
           # Most of them have defaults for all parameters
           QualityFactor(),
-          L1(depth=1*u.mu, order_selector=OrderSelector([0])),
+          L1(order_selector=OrderSelector([0])),
           L2Abs(),
           L2Diffraction(),
           CATL1L2Stack(order_selector=OrderSelector([2])),


### PR DESCRIPTION
Before this change, the L1 dimensions were hardcoded. Now, the specs
of some currently produced gratings are hold in a module-level variable,
but other dimensiosn can be used. This matches what was done for the
L2 support before.