### PR TITLE
x3d visualization: transparancy/opacity

### DIFF
--- a/docs/pyplots/vis_subaperturing.py
+++ b/docs/pyplots/vis_subaperturing.py
@@ -2,7 +2,6 @@ import copy
 import numpy as np
 import matplotlib.pyplot as plt
 from marxs import optics, design, analysis, source, simulator
-from marxs.design import rowland
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 

--- a/marxs/visualization/tests/test_x3d.py
+++ b/marxs/visualization/tests/test_x3d.py
@@ -33,7 +33,7 @@ def test_box():
     out_expected = '''<Scene>
   <Shape>
     <Appearance>
-      <Material diffuseColor='1.0 1.0 0.0'/>
+      <Material diffuseColor='1.0 1.0 0.0' transparency='0.9'/>
     </Appearance>
     <IndexedFaceSet colorPerVertex='false' coordIndex='0 2 3 1 -1 4 6 7 5 -1 0 4 6 2 -1 1 5 7 3 -1 0 4 5 1 -1 2 6 7 3 -1' solid='false'>
       <Coordinate point='0.0 1.0 2.0 0.0 5.0 2.0 0.0 1.0 6.0 0.0 5.0 6.0 2.0 1.0 2.0 2.0 5.0 2.0 2.0 1.0 6.0 2.0 5.0 6.0'/>
@@ -52,7 +52,7 @@ def test_aperture():
     out_expected = '''<Scene>
   <Shape>
     <Appearance>
-      <Material diffuseColor='0.0 0.75 0.75'/>
+      <Material diffuseColor='0.0 0.75 0.75' transparency='0.7'/>
     </Appearance>
     <IndexedTriangleSet colorPerVertex='false' index='0 4 5 0 1 5 1 5 6 1 2 6 2 6 7 2 3 7 3 7 4 3 0 4' solid='false'>
       <Coordinate point='0.0 15.0 15.0 0.0 -15.0 15.0 0.0 -15.0 -15.0 0.0 15.0 -15.0 0.0 5.0 5.0 0.0 -5.0 5.0 0.0 -5.0 -5.0 0.0 5.0 -5.0'/>

--- a/marxs/visualization/x3d.py
+++ b/marxs/visualization/x3d.py
@@ -99,10 +99,15 @@ class Scene(x3d.Scene):
 def empty_scene(func):
     @wraps(func)
     def with_scene(*args, **kwargs):
-        if not 'scene' in kwargs or kwargs['scene'] is None:
+        if 'scene' not in kwargs or kwargs['scene'] is None:
             kwargs['scene'] = Scene(children=[])
         return func(*args, **kwargs)
     return with_scene
+
+
+def _diffuse_material(display):
+    return x3d.Material(diffuseColor=display['color'],
+                        transparency=1 - display.get('opacity', 1.))
 
 
 @empty_scene
@@ -126,7 +131,7 @@ def indexed_triangle_set(xyz, index, display, *, scene):
     scene : `marxs.visualization.x3d.Scene` object
         Scene with object added.
     '''
-    scene.children.append(x3d.Shape(appearance=x3d.Appearance(material=x3d.Material(diffuseColor=display['color'])),
+    scene.children.append(x3d.Shape(appearance=x3d.Appearance(material=_diffuse_material(display)),
                      geometry=x3d.IndexedTriangleSet(coord=x3d.Coordinate(point=[tuple(p) for p in xyz]),
                                                      index=[int(i) for i in index.reshape(-1, 3).flatten()],
                                                      solid=False, colorPerVertex=False)))
@@ -153,7 +158,7 @@ def surface(obj, display, *, scene):
     index = np.vstack([np.arange(i, i + 2 * n, 2, dtype=int) for i in [0, 2, 3, 1]] + 
                       # Add -1 at the end of each row to mark end of each face
                       [-1 * np.ones(n, dtype=int)]).T.flatten()
-    scene.children.append(x3d.Shape(appearance=x3d.Appearance(material=x3d.Material(diffuseColor=display['color'])),
+    scene.children.append(x3d.Shape(appearance=x3d.Appearance(material=_diffuse_material(display)),
                                     geometry=x3d.IndexedFaceSet(coord=
                                         x3d.Coordinate(point=[tuple(p) for p in xyz.reshape((-1, 3))]),
                                         coordIndex=[int(i) for i in index],
@@ -183,7 +188,7 @@ def box(obj, display, *, scene):
     photon interaction happens on the surface, not in the substrate.
     '''
     corners = utils.halfbox_corners(obj, display)
-    shape = x3d.Shape(appearance=x3d.Appearance(material=x3d.Material(diffuseColor=display['color'])),
+    shape = x3d.Shape(appearance=x3d.Appearance(material=_diffuse_material(display)),
                      geometry=x3d.IndexedFaceSet(coord=x3d.Coordinate(point=[tuple(p) for p in corners]),
                                                  coordIndex=[0, 2, 3, 1, -1, 
                                                              4, 6, 7, 5, -1,


### PR DESCRIPTION
In the docs for visualization we promise a backend-independent option for opacity. X3D instead uses transparency, but we translate from "opacity" to make this common option work with as many backends as we can.