### PR TITLE
``CCDRedistNormal`` now inherits from an optical element .

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,6 +82,11 @@ API Changes
   of importing from the higher level such as `from marxs.optics import Baffle` should not notice
   any difference. [#424]
 
+- The unit of photon energy is now set to keV. [#252]
+
+- ``CCDRedistNormal`` now inherits from an optical element and takes the sigma for redistribution
+  as a keyword argument. [#252]
+
 Bug fixes
 ^^^^^^^^^
 

--- a/marxs/missions/arcus/tests/test_arfrmf.py
+++ b/marxs/missions/arcus/tests/test_arfrmf.py
@@ -126,8 +126,11 @@ def test_make_arf_osip():
                             arfrmf.filename_from_meta('arf', **arf.meta))
             arf.write(basearf)
 
-        osipp = osip.FixedFractionOSIP(0.7, ccd_redist=CCDRedistNormal(tab_redist),
-                                       filename_from_meta=arfrmf.filename_from_meta)
+        osipp = osip.FixedFractionOSIP(
+            0.7,
+            ccd_redist=CCDRedistNormal(tab_width=tab_redist),
+            filename_from_meta=arfrmf.filename_from_meta,
+        )
         osipp.apply_osip_all(tmpdirname, tmpdirname, [-5],
                              filename_from_meta_kwargs={'ARCCHAN': '1111'})
 

--- a/marxs/reduction/osip.py
+++ b/marxs/reduction/osip.py
@@ -21,10 +21,10 @@ __all__ = ['OSIPBase',
 
 
 class OSIPBase(ABC):
-    '''Modify ARF files to account for order-sorting effects
+    """Modify ARF files to account for order-sorting effects
 
     This is a base class that implements order sorting and integration of
-    the probabilities (OSIP). This includes order-sorting of a photons list
+    the probabilities (OSIP). This includes order-sorting of a photon list
     (not yet implemented) and  methods to modify ARF files
     to account for order-sorting. Different diffraction orders fall on
     the same physical space on the CCD. The CCD energy resolution can
@@ -48,7 +48,7 @@ class OSIPBase(ABC):
         Function that return the width the Gaussian sigma of the CCD
         resolution, given an input energy.
         TODO: Better docs here
-    '''
+    """
     osip_description = 'Not implemented'
     '''String to be added to FITS header in OSIP keyword for ARFs written.'''
 
@@ -395,7 +395,7 @@ class OSIPBase(ABC):
 
 
 class FixedWidthOSIP(OSIPBase):
-    '''Modify ARF files to account for order-sorting effects
+    """Modify ARF files to account for order-sorting effects
 
     This class implements order sorting and integration of
     the probabilities (OSIP) for order-sorting regions that have a fixed witdh
@@ -420,9 +420,9 @@ class FixedWidthOSIP(OSIPBase):
     offset_orders : list of int
         Offset from main order that is relevant.
     ccd_redist : callable
-        Function that return the width the Gaussian sigma of the CCD
+        Function that returns the width the Gaussian sigma of the CCD
         resolution, given an input energy.
-    '''
+    """
     def __init__(self, halfwidth, **kwargs):
         self.halfwidth = halfwidth
         super().__init__(**kwargs)

--- a/marxs/reduction/tests/test_osip.py
+++ b/marxs/reduction/tests/test_osip.py
@@ -19,7 +19,7 @@ from astropy.utils.data import get_pkg_data_filename
 filename = get_pkg_data_filename('data/ccd_redist_normal.ecsv', 'marxs.optics.tests')
 tab_redist = QTable.read(filename)
 
-ccd_redist = CCDRedistNormal(tab_redist)
+ccd_redist = CCDRedistNormal(tab_width=tab_redist)
 osipf = FixedWidthOSIP(40 * u.eV, ccd_redist=ccd_redist)
 osipp = FixedFractionOSIP(0.7, ccd_redist=ccd_redist)
 osipd = FractionalDistanceOSIP(ccd_redist=ccd_redist)
@@ -60,8 +60,7 @@ def test_osip_factor():
     assert np.allclose(wide.osip_factor([10] * u.Angstrom, -5, -5), 1)
     '''test with fixed sigma'''
     sig = QTable({'energy': [0, 1, 2] * u.keV, 'sigma': [40, 40, 40] * u.eV})
-    myosip = FixedWidthOSIP(40 * u.eV,
-                            ccd_redist=CCDRedistNormal(sig))
+    myosip = FixedWidthOSIP(40 * u.eV, ccd_redist=CCDRedistNormal(tab_width=sig))
 
     assert np.allclose(myosip.osip_factor([10] * u.Angstrom, -5, -5),
                        0.6827, rtol=1e-4)

--- a/marxs/utils.py
+++ b/marxs/utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 from astropy.table import Table
+import astropy.units as u
 import warnings
 
 __all__ = ['SimulationSetupWarning', 'generate_test_photons',
@@ -38,12 +39,15 @@ def generate_test_photons(n=1):
     dir = np.tile(np.array([-1., 0., 0., 0.]), (n, 1))
     pos = np.tile(np.array([1., 0., 0., 1.]), (n, 1))
     pol = np.tile(np.array([0., 1., 0., 0.]), (n, 1))
-    photons = Table({'pos': pos,
-                     'dir': dir,
-                     'energy': np.ones(n),
-                     'polarization': pol,
-                     'probability': np.ones(n),
-                     })
+    photons = Table(
+        {
+            "pos": pos,
+            "dir": dir,
+            "energy": np.ones(n) * u.keV,
+            "polarization": pol,
+            "probability": np.ones(n),
+        }
+    )
     return photons
 
 


### PR DESCRIPTION
That means that it can gain a `special process photons` method and be called as part of the instrument definition.