### PR TITLE
Fix direct failures with numpy >= 2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ API Changes
 Bug fixes
 ^^^^^^^^^
 
+- Fix test failures with numpy 2.0 [#254]
+
 Other changes and additions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/conventions.rst
+++ b/docs/conventions.rst
@@ -92,7 +92,7 @@ There are two ways to specify that:
 
       >>> baf2 = Baffle(zoom=[1., 2., 2.], position=[5., 0., 0.])
       >>> np.all(baf2.pos4d == baf1.pos4d)
-      True
+      np.True_
 
 
   It is an error to specify ``pos4d`` and any of the ``orientation``, ``zoom``, and ``position``

--- a/marxs/design/tests/test_design.py
+++ b/marxs/design/tests/test_design.py
@@ -217,7 +217,7 @@ def test_GratingArrayStructure():
     assert gas.max_elements_on_arc(300.) == 12
     angles = gas.distribute_elements_on_arc(315.) % (2. * np.pi)
     # This is a wrap-around case. Hard to test in general, but here I know the numbers
-    assert np.alltrue((angles < 0.2 * np.pi) | (angles > 1.8 * np.pi))
+    assert np.all((angles < 0.2 * np.pi) | (angles > 1.8 * np.pi))
     assert gas.max_elements_on_radius(gas.radius) == 10
     assert np.all(gas.distribute_elements_on_radius() == np.arange(315., 600., 30.))
     assert len(gas.elem_pos) == 177
@@ -248,7 +248,7 @@ def test_GAS_multipleradii():
     r1 = gas1.distribute_elements_on_radius()
     r2 = gas2.distribute_elements_on_radius()
     r = gas.distribute_elements_on_radius()
-    assert np.all(np.in1d(r, np.union1d(r1, r2)))
+    assert np.all(np.isin(r, np.union1d(r1, r2)))
 
 
 def test_GratingArrayStructure_2pi():

--- a/marxs/simulator/simulator.py
+++ b/marxs/simulator/simulator.py
@@ -143,7 +143,7 @@ class BaseContainer(SimulationSequenceElement):
 
 
 class Sequence(BaseContainer):
-    '''A `Sequence` is a container that summarizes several optical elements.
+    """A `Sequence` is a container that summarizes several optical elements.
 
     Parameters
     ----------
@@ -192,11 +192,11 @@ class Sequence(BaseContainer):
     Now, let us check where the photons fall on the detector:
 
     >>> set(photons_out['detpix_x'].round())
-    {19.0, 20.0}
+    {np.float64(19.0), np.float64(20.0)}
 
     As expected, they fall right around the center of the detector (row 19 and 20 of a
     40 * 40 pixel detector).
-    '''
+    """
 
     def __init__(self, **kwargs):
         self.elements = kwargs.pop('elements')

--- a/marxs/visualization/tests/test_x3d.py
+++ b/marxs/visualization/tests/test_x3d.py
@@ -87,17 +87,17 @@ def test_surface():
 def test_rays():
     '''Just two rays to make sure the format is right.'''
     rays = plot_rays(np.arange(12).reshape(2,2,3))
-    out_expected = '''<Scene>
+    out_expected = """<Scene>
   <Shape>
     <Appearance>
       <Material emissiveColor='0.27 0.0 0.33'/>
     </Appearance>
     <LineSet vertexCount='2 2'>
-      <Coordinate point='0 1 2 3 4 5 6 7 8 9 10 11'/>
+      <Coordinate point='0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0 10.0 11.0'/>
     </LineSet>
   </Shape>
 </Scene>
-'''
+"""
     compare_trimmed(rays.XML(), out_expected)
 
 


### PR DESCRIPTION
This commit does not address a much larger number of warning from pending deprecation, since most of those originate in dependencies (sherpa and transforms3d).